### PR TITLE
Fixing squid:UselessParenthesesCheck  Useless parentheses around exprssions should be removed to prevent any misunderstanding

### DIFF
--- a/advanced/attributes/src/main/java/org/arakhne/afc/attrs/attr/AttributeValueImpl.java
+++ b/advanced/attributes/src/main/java/org/arakhne/afc/attrs/attr/AttributeValueImpl.java
@@ -327,7 +327,7 @@ public class AttributeValueImpl implements AttributeValue, AttributeConstants {
 	public AttributeValueImpl(UUID value) {
 		this.type = AttributeType.UUID;
 		this.value = (value!=null) ? new UUID(value.getMostSignificantBits(), value.getLeastSignificantBits()) : null;
-		this.assigned = (this.value!=null);
+		this.assigned = this.value!=null;
 	}
 
 	/**
@@ -341,7 +341,7 @@ public class AttributeValueImpl implements AttributeValue, AttributeConstants {
 		catch (MalformedURLException e) {
 			this.value = null;
 		}
-		this.assigned = (this.value!=null);
+		this.assigned = this.value!=null;
 	}
 
 	/**
@@ -355,7 +355,7 @@ public class AttributeValueImpl implements AttributeValue, AttributeConstants {
 		catch (URISyntaxException e) {
 			this.value = null;
 		}
-		this.assigned = (this.value!=null);
+		this.assigned = this.value!=null;
 	}
 
 	/**
@@ -364,7 +364,7 @@ public class AttributeValueImpl implements AttributeValue, AttributeConstants {
 	public AttributeValueImpl(InetAddress value) {
 		this.type = AttributeType.INET_ADDRESS;
 		this.value = (value!=null) ? value : null;
-		this.assigned = (this.value!=null);
+		this.assigned = this.value!=null;
 	}
 
 	/**
@@ -373,7 +373,7 @@ public class AttributeValueImpl implements AttributeValue, AttributeConstants {
 	public AttributeValueImpl(InetSocketAddress value) {
 		this.type = AttributeType.INET_ADDRESS;
 		this.value = (value!=null) ? value.getAddress() : null;
-		this.assigned = (this.value!=null);
+		this.assigned = this.value!=null;
 	}
 
 	/**
@@ -382,7 +382,7 @@ public class AttributeValueImpl implements AttributeValue, AttributeConstants {
 	public AttributeValueImpl(Enum<?> value) {
 		this.type = AttributeType.ENUMERATION;
 		this.value = (value!=null) ? value : null;
-		this.assigned = (this.value!=null);
+		this.assigned = this.value!=null;
 	}
 
 	/**
@@ -391,7 +391,7 @@ public class AttributeValueImpl implements AttributeValue, AttributeConstants {
 	public AttributeValueImpl(Class<?> value) {
 		this.type = AttributeType.TYPE;
 		this.value = (value!=null) ? value : null;
-		this.assigned = (this.value!=null);
+		this.assigned = this.value!=null;
 	}
 
 	/**
@@ -400,7 +400,7 @@ public class AttributeValueImpl implements AttributeValue, AttributeConstants {
 	public AttributeValueImpl(Date value) {
 		this.type = AttributeType.DATE;
 		this.value = (value!=null) ? new Date(value.getTime()) : null;
-		this.assigned = (this.value!=null);
+		this.assigned = this.value!=null;
 	}
 
 	/**
@@ -456,7 +456,7 @@ public class AttributeValueImpl implements AttributeValue, AttributeConstants {
 	public AttributeValueImpl(Point2D value) {
 		this.type = AttributeType.POINT;
 		this.value = value;
-		this.assigned = (this.value!=null);
+		this.assigned = this.value!=null;
 	}
 
 	/**
@@ -516,7 +516,7 @@ public class AttributeValueImpl implements AttributeValue, AttributeConstants {
 	public AttributeValueImpl(String value) {
 		this.type = AttributeType.STRING;
 		this.value = value;
-		this.assigned = (value!=null);
+		this.assigned = value!=null;
 	}
 
 	/**
@@ -525,7 +525,7 @@ public class AttributeValueImpl implements AttributeValue, AttributeConstants {
 	public AttributeValueImpl(Point2D[] value) {
 		this.type = AttributeType.POLYLINE;
 		this.value = value;
-		this.assigned = (this.value!=null);
+		this.assigned = this.value!=null;
 	}
 
 	/**
@@ -534,7 +534,7 @@ public class AttributeValueImpl implements AttributeValue, AttributeConstants {
 	public AttributeValueImpl(Point3D[] value) {
 		this.type = AttributeType.POLYLINE3D;
 		this.value = value;
-		this.assigned = (this.value!=null);
+		this.assigned = this.value!=null;
 	}
 
 	/**
@@ -611,7 +611,7 @@ public class AttributeValueImpl implements AttributeValue, AttributeConstants {
 	 * @return <code>true</code> if the value is not assigned or equals to <code>null</code>.
 	 */
 	private boolean isNotAssignedOrNull() {
-		return ((!this.assigned)||(this.value==null));
+		return (!this.assigned)||(this.value==null);
 	}
 	
 	/** Assert that the attribute value was assigned.
@@ -833,7 +833,7 @@ public class AttributeValueImpl implements AttributeValue, AttributeConstants {
 	public void setValue(Object value) {
 		AttributeType detectedType = AttributeType.fromValue(value);
 		this.value = detectedType.cast(value);
-		this.assigned = (this.value!=null);
+		this.assigned = this.value!=null;
 	}
 
 	/** Set this value with the content of the specified one.
@@ -847,7 +847,7 @@ public class AttributeValueImpl implements AttributeValue, AttributeConstants {
 	 */
 	protected void setInternalValue(Object value) {
 		this.value = value;
-		this.assigned = (this.value!=null);
+		this.assigned = this.value!=null;
 	}
 
 	/** Set this value with the content of the specified one.
@@ -863,7 +863,7 @@ public class AttributeValueImpl implements AttributeValue, AttributeConstants {
 	 */
 	protected void setInternalValue(Object value, AttributeType type) {
 		this.value = value;
-		this.assigned = (this.value!=null);
+		this.assigned = this.value!=null;
 		this.type = type;
 	}
 
@@ -1024,7 +1024,7 @@ public class AttributeValueImpl implements AttributeValue, AttributeConstants {
 				return ((Boolean)this.value).toString();
 			case COLOR:
 			{
-				Color col = ((Color)this.value);
+				Color col = (Color)this.value;
 				return Integer.toString(col.getRed())
 					+';'+col.getGreen()
 					+';'+col.getBlue()
@@ -1032,17 +1032,17 @@ public class AttributeValueImpl implements AttributeValue, AttributeConstants {
 			}
 			case UUID:
 			{
-				UUID uuid = ((UUID)this.value);
+				UUID uuid = (UUID)this.value;
 				return uuid.toString();
 			}
 			case URL:
 			{
-				URL url = ((URL)this.value);
+				URL url = (URL)this.value;
 				return url.toExternalForm();
 			}
 			case URI:
 			{
-				URI uri = ((URI)this.value);
+				URI uri = (URI)this.value;
 				return uri.toASCIIString();
 			}
 			case TIMESTAMP:
@@ -1055,14 +1055,14 @@ public class AttributeValueImpl implements AttributeValue, AttributeConstants {
 			case REAL:
 				return ((Double)this.value).toString();
 			case POINT:
-				Point2D pt2 = ((Point2D)this.value);
+				Point2D pt2 = (Point2D)this.value;
 				StringBuilder buffer = new StringBuilder();
 				buffer.append(pt2.getX());
 				buffer.append(";"); //$NON-NLS-1$
 				buffer.append(pt2.getY());
 				return buffer.toString();
 			case POINT3D:
-				Point3D pt3 = ((Point3D)this.value);
+				Point3D pt3 = (Point3D)this.value;
 				buffer = new StringBuilder();
 				buffer.append(pt3.getX());
 				buffer.append(";"); //$NON-NLS-1$
@@ -1078,7 +1078,7 @@ public class AttributeValueImpl implements AttributeValue, AttributeConstants {
 			case POLYLINE:
 			{ 
 				buffer = new StringBuilder();
-				Point2D[] lstpt2 = ((Point2D[])this.value);
+				Point2D[] lstpt2 = (Point2D[])this.value;
 				for(int i=0; i<lstpt2.length; ++i) {
 					if (lstpt2[i]!=null) {
 						if (buffer.length()>0) buffer.append(";"); //$NON-NLS-1$
@@ -1092,7 +1092,7 @@ public class AttributeValueImpl implements AttributeValue, AttributeConstants {
 			case POLYLINE3D:
 			{ 
 				buffer = new StringBuilder();
-				Point3D[] lstpt3 = ((Point3D[])this.value);
+				Point3D[] lstpt3 = (Point3D[])this.value;
 				for(int i=0; i<lstpt3.length; ++i) {
 					if (lstpt3[i]!=null) {
 						if (buffer.length()>0) buffer.append(";"); //$NON-NLS-1$
@@ -1983,7 +1983,7 @@ public class AttributeValueImpl implements AttributeValue, AttributeConstants {
 			this.value = (id!=null) ? UUID.fromString(id) : null;
 		}
 		catch(Throwable exception) {
-			assert(id!=null);
+			assert id!=null;
 			this.value = UUID.nameUUIDFromBytes(id.getBytes());
 		}
 		this.type = AttributeType.UUID;				
@@ -2094,7 +2094,7 @@ public class AttributeValueImpl implements AttributeValue, AttributeConstants {
 			return null;
 		}
 		int fullPoints = comp.length/3;
-		boolean addPt = (fullPoints*3!=comp.length); 
+		boolean addPt = fullPoints*3!=comp.length;
 		Point3D[] tab = new Point3D[addPt ? fullPoints+1 : fullPoints];
 		for(int i=2,j=0; (i<comp.length)&&(j<tab.length); i+=3,++j) {
 			tab[j] = null; // FIXME: fix code: new Point3f(
@@ -2275,7 +2275,7 @@ public class AttributeValueImpl implements AttributeValue, AttributeConstants {
 			return null;
 		}
 		int fullPoints = comp.length/2;
-		boolean addPt = (fullPoints*2!=comp.length); 
+		boolean addPt = fullPoints*2!=comp.length;
 		Point2D[] tab = new Point2D[addPt ? fullPoints+1 : fullPoints];
 		for(int i=1,j=0; (i<comp.length)&&(j<fullPoints); i+=2,++j) {
 			// FIXME: Fixcode: tab[j] = new Point2f(
@@ -2616,7 +2616,7 @@ public class AttributeValueImpl implements AttributeValue, AttributeConstants {
 					String classname = ((String)this.value).substring(0, index);
 					String enumName = ((String)this.value).substring(index+1);
 					Class<?> classType = Class.forName(classname);
-					assert(type.equals(classType));
+					assert type.equals(classType);
 					return Enum.valueOf(type, enumName);
 				}
 				break;

--- a/advanced/attributes/src/main/java/org/arakhne/afc/attrs/collection/HeapAttributeCollection.java
+++ b/advanced/attributes/src/main/java/org/arakhne/afc/attrs/collection/HeapAttributeCollection.java
@@ -337,7 +337,7 @@ public class HeapAttributeCollection extends AbstractAttributeCollection {
 	 */
 	@Override
 	public Attribute setAttributeType(String name, AttributeType type) throws AttributeException {
-		assert(name!=null);
+		assert name!=null;
 
 		AttributeValue oldValue = copyValue(name);
 		AttributeType oldType = (oldValue==null) ? null : oldValue.getType();
@@ -359,7 +359,7 @@ public class HeapAttributeCollection extends AbstractAttributeCollection {
 	 */
 	@Override
 	public Attribute setAttribute(String name, AttributeValue value) throws AttributeException {
-		assert(name!=null && value!=null);
+		assert name!=null && value!=null;
 		AttributeValue oldValue = copyValue(name);
 		
 		if (oldValue!=null && oldValue.equals(value)) return null;
@@ -381,7 +381,7 @@ public class HeapAttributeCollection extends AbstractAttributeCollection {
 	 */
 	@Override
 	public Attribute setAttribute(String name, boolean value) {
-		assert(name!=null);
+		assert name!=null;
 
 		AttributeValue oldValue = copyValue(name);
 		
@@ -404,7 +404,7 @@ public class HeapAttributeCollection extends AbstractAttributeCollection {
 	 */
 	@Override
 	public Attribute setAttribute(String name, int value) {
-		assert(name!=null);
+		assert name!=null ;
 
 		AttributeValue oldValue = copyValue(name);
 		
@@ -427,7 +427,7 @@ public class HeapAttributeCollection extends AbstractAttributeCollection {
 	 */
 	@Override
 	public Attribute setAttribute(String name, long value) {
-		assert(name!=null);
+		assert name!=null ;
 
 		AttributeValue oldValue = copyValue(name);
 		
@@ -450,7 +450,7 @@ public class HeapAttributeCollection extends AbstractAttributeCollection {
 	 */
 	@Override
 	public Attribute setAttribute(String name, float value) {
-		assert(name!=null);
+		assert name!=null;
 
 		AttributeValue oldValue;
 		Object currentValue = this.heap.get(name);
@@ -481,7 +481,7 @@ public class HeapAttributeCollection extends AbstractAttributeCollection {
 	 */
 	@Override
 	public Attribute setAttribute(String name, double value) {
-		assert(name!=null);
+		assert name!=null;
 
 		AttributeValue oldValue = copyValue(name);
 		
@@ -504,7 +504,7 @@ public class HeapAttributeCollection extends AbstractAttributeCollection {
 	 */
 	@Override
 	public Attribute setAttribute(String name, String value) {
-		assert(name!=null);
+		assert name!=null;
 
 		AttributeValue oldValue = copyValue(name);
 		
@@ -530,7 +530,7 @@ public class HeapAttributeCollection extends AbstractAttributeCollection {
 	 */
 	@Override
 	public Attribute setAttribute(String name, UUID value) {
-		assert(name!=null);
+		assert name!=null;
 
 		AttributeValue oldValue = copyValue(name);
 		
@@ -556,7 +556,7 @@ public class HeapAttributeCollection extends AbstractAttributeCollection {
 	 */
 	@Override
 	public Attribute setAttribute(String name, URL value) {
-		assert(name!=null);
+		assert name!=null;
 
 		AttributeValue oldValue = copyValue(name);
 		
@@ -581,7 +581,7 @@ public class HeapAttributeCollection extends AbstractAttributeCollection {
 	 */
 	@Override
 	public Attribute setAttribute(String name, URI value) {
-		assert(name!=null);
+		assert name!=null;
 
 		AttributeValue oldValue = copyValue(name);
 		
@@ -607,7 +607,7 @@ public class HeapAttributeCollection extends AbstractAttributeCollection {
 	@Override
 	@Deprecated
 	public Attribute setAttribute(String name, Image value) {
-		assert(name!=null);
+		assert name!=null;
 
 		AttributeValue oldValue = copyValue(name);
 		
@@ -632,7 +632,7 @@ public class HeapAttributeCollection extends AbstractAttributeCollection {
 	 */
 	@Override
 	public Attribute setAttribute(String name, Date value) {
-		assert(name!=null);
+		assert name!=null;
 
 		AttributeValue oldValue = copyValue(name);
 		
@@ -659,7 +659,7 @@ public class HeapAttributeCollection extends AbstractAttributeCollection {
 	@Override
 	@Deprecated
 	public Attribute setAttribute(String name, Color value) {
-		assert(name!=null);
+		assert name!=null;
 
 		AttributeValue oldValue = copyValue(name);
 		
@@ -685,7 +685,7 @@ public class HeapAttributeCollection extends AbstractAttributeCollection {
 	 */
 	@Override
 	public Attribute setAttribute(Attribute value) throws AttributeException {
-		assert(value!=null);
+		assert value!=null;
 		String name = value.getName();
 		AttributeValue oldValue = copyValue(name);
 		
@@ -706,7 +706,7 @@ public class HeapAttributeCollection extends AbstractAttributeCollection {
 	 */
 	@Override
 	public Attribute setAttribute(String name, InetAddress value) {
-		assert(name!=null);
+		assert name!=null;
 
 		AttributeValue oldValue = copyValue(name);
 		
@@ -737,7 +737,7 @@ public class HeapAttributeCollection extends AbstractAttributeCollection {
 	 */
 	@Override
 	public Attribute setAttribute(String name, Enum<?> value) {
-		assert(name!=null);
+		assert name!=null;
 
 		AttributeValue oldValue = copyValue(name);
 		
@@ -760,7 +760,7 @@ public class HeapAttributeCollection extends AbstractAttributeCollection {
 	 */
 	@Override
 	public Attribute setAttribute(String name, Class<?> value) {
-		assert(name!=null);
+		assert name!=null;
 
 		AttributeValue oldValue = copyValue(name);
 		
@@ -783,7 +783,7 @@ public class HeapAttributeCollection extends AbstractAttributeCollection {
 	 */
 	@Override
 	public boolean removeAttribute(String name) {
-		assert(name!=null);
+		assert name!=null;
 
 		AttributeValue oldValue;
 		Object currentValue = this.heap.remove(name);

--- a/advanced/attributes/src/main/java/org/arakhne/afc/attrs/collection/MultiAttributeProvider.java
+++ b/advanced/attributes/src/main/java/org/arakhne/afc/attrs/collection/MultiAttributeProvider.java
@@ -119,7 +119,7 @@ public class MultiAttributeProvider extends AbstractAttributeProvider {
 			v1.setMultipleValues(true);
 		}
 		else {
-			assert(v2.isAssigned());
+			assert v2.isAssigned();
 			if (!v1.isAssigned()) {
 				v1.setValue(v2);
 			}

--- a/core/math/src/main/java/org/arakhne/afc/math/DoubleRange.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/DoubleRange.java
@@ -46,7 +46,7 @@ public class DoubleRange implements Cloneable, Serializable, Comparable<DoubleRa
 	 * @param max
 	 */
 	public DoubleRange(double min, double max) {
-		assert (min <= max) : "min must be lower or equal to max"; //$NON-NLS-1$
+		assert min <= max : "min must be lower or equal to max"; //$NON-NLS-1$
 		this.min = min;
 		this.max = max;
 	}

--- a/core/math/src/main/java/org/arakhne/afc/math/MathUtil.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/MathUtil.java
@@ -77,7 +77,7 @@ public final class MathUtil {
 	 */
 	@Pure
 	public static double clamp(double v, double min, double max) {
-		assert (min <= max) : "min must be lower or equal to max"; //$NON-NLS-1$
+		assert min <= max : "min must be lower or equal to max"; //$NON-NLS-1$
 		if (v < min) return min;
 		if (v > max) return max;
 		return v;
@@ -96,7 +96,7 @@ public final class MathUtil {
 	 */
 	@Pure
 	public static int clamp(int v, int min, int max) {
-		assert (min <= max) : "min must be lower or equal to max"; //$NON-NLS-1$
+		assert min <= max : "min must be lower or equal to max"; //$NON-NLS-1$
 		if (v < min) return min;
 		if (v > max) return max;
 		return v;
@@ -377,7 +377,7 @@ public final class MathUtil {
 	 */
 	@Pure
 	public static double clampCyclic(double value, double min, double max) {
-		assert (min <= max) : "min must be lower or equal to max"; //$NON-NLS-1$
+		assert min <= max : "min must be lower or equal to max"; //$NON-NLS-1$
 		if (Double.isNaN(max) || Double.isNaN(min) || Double.isNaN(max)) {
 			return Double.NaN;
 		}
@@ -393,7 +393,7 @@ public final class MathUtil {
 		else if (value >= max) {
 			double perimeter = max - min;
 			double nvalue = value - max;
-			double rest = (nvalue % perimeter);
+			double rest = nvalue % perimeter;
 			return min + rest;
 		}
 		return value;
@@ -413,7 +413,7 @@ public final class MathUtil {
 	 */
 	@Pure
 	public static double clampToNearestBounds(double value, double minBounds, double maxBounds) {
-		assert (minBounds <= maxBounds) : "min must be lower or equal to max"; //$NON-NLS-1$
+		assert minBounds <= maxBounds : "min must be lower or equal to max"; //$NON-NLS-1$
 		double center = (minBounds+maxBounds) / 2f;
 		if (value<=center) return minBounds;
 		return maxBounds;
@@ -432,8 +432,8 @@ public final class MathUtil {
 	 */
 	@Pure
 	public static int getCohenSutherlandCode(int px, int py, int rxmin, int rymin, int rxmax, int rymax) {
-		assert (rxmin <= rxmax) : "rxmin must be lower or equal to rxmax"; //$NON-NLS-1$
-		assert (rymin <= rymax) : "rymin must be lower or equal to rymax"; //$NON-NLS-1$
+		assert rxmin <= rxmax : "rxmin must be lower or equal to rxmax"; //$NON-NLS-1$
+		assert rymin <= rymax : "rymin must be lower or equal to rymax"; //$NON-NLS-1$
 		// initialised as being inside of clip window
 		int code = COHEN_SUTHERLAND_INSIDE;
 		if (px<rxmin) {
@@ -471,8 +471,8 @@ public final class MathUtil {
 	 */
 	@Pure
 	public static int getCohenSutherlandCode(double px, double py, double rxmin, double rymin, double rxmax, double rymax) {
-		assert (rxmin <= rxmax) : "rxmin must be lower or equal to rxmax"; //$NON-NLS-1$
-		assert (rymin <= rymax) : "rymin must be lower or equal to rymax"; //$NON-NLS-1$
+		assert rxmin <= rxmax : "rxmin must be lower or equal to rxmax"; //$NON-NLS-1$
+		assert rymin <= rymax : "rymin must be lower or equal to rymax"; //$NON-NLS-1$
 		// initialised as being inside of clip window
 		int code = COHEN_SUTHERLAND_INSIDE;
 		if (px < rxmin) {
@@ -1010,7 +1010,7 @@ public final class MathUtil {
 			if (value>max) return max - Float.MAX_VALUE + value;
 		}
 		else {
-			assert(min<=max);
+			assert min<=max;
 			if (min==max) return min; // special case: empty interval
 			if (value<min || value >max) {
 				float perimeter = max - min;
@@ -1150,7 +1150,7 @@ public final class MathUtil {
 	public static boolean isPointClosedToSegment( float x1, float y1, 
 			float x2, float y2, 
 			float x, float y, float hitDistance ) {
-		return ( distancePointToSegment(x, y, x1, y1, x2, y2) < hitDistance ) ;
+		return  distancePointToSegment(x, y, x1, y1, x2, y2) < hitDistance;
 	}
 
 	/** Replies if a point is closed to a line.
@@ -1170,7 +1170,7 @@ public final class MathUtil {
 	public static boolean isPointClosedToLine( float x1, float y1, 
 			float x2, float y2, 
 			float x, float y, float hitDistance ) {
-		return ( distancePointToLine(x, y, x1, y1, x2, y2) < hitDistance ) ;
+		return distancePointToLine(x, y, x1, y1, x2, y2) < hitDistance;
 	}
 
 	/** Replies the metrics from inches.
@@ -1207,7 +1207,7 @@ public final class MathUtil {
 	 */
 	@Deprecated
 	public static float clampAngle( float value, float min, float max ) {
-		assert(min<=max);
+		assert min<=max;
 		float v = value;
 		while (v>max) {
 			v -= 2*Math.PI;
@@ -1231,7 +1231,7 @@ public final class MathUtil {
 	 */
 	@Deprecated
 	public static float clampToNearestBounds( float value, float minBounds, float maxBounds ) {
-		assert(minBounds<=maxBounds);
+		assert minBounds<=maxBounds;
 		float center = (minBounds+maxBounds) / 2f;
 		if (value<=center) return minBounds;
 		return maxBounds;
@@ -1574,8 +1574,8 @@ public final class MathUtil {
 		float y4 = y3 + v2.getY();
 		float denom = (y4-y3)*(x2-x1) - (x4-x3)*(y2-y1);
 		if (denom==0.) return null;
-		float ua = ((x4-x3)*(y1-y3) - (y4-y3)*(x1-x3));
-		float ub = ((x2-x1)*(y1-y3) - (y2-y1)*(x1-x3));
+		float ua = (x4-x3)*(y1-y3) - (y4-y3)*(x1-x3);
+		float ub = (x2-x1)*(y1-y3) - (y2-y1)*(x1-x3);
 		if (ua==ub) return null;
 		ua = ua / denom;
 		return new Point2f(
@@ -1775,7 +1775,7 @@ public final class MathUtil {
 				float y0 = py - (ey + b);
 
 				float denom = a*a*y0*y0 + b*b*x0*x0;
-				assert(denom>0f); // because the "inside"-test should discard this case.
+				assert denom>0f; // because the "inside"-test should discard this case.
 
 				denom = (float)Math.sqrt(denom);
 				float factor = (a * b) / denom;
@@ -2076,7 +2076,7 @@ public final class MathUtil {
 	 */
 	@Deprecated
 	public static boolean isCollinearLines(float x1, float y1, float x2, float y2, float x3, float y3, float x4, float y4) {
-		return (isParallelLines(x1, y1, x2, y2, x3, y3, x4, y4) && isCollinearPoints(x1, y1, x2, y2, x3, y3));
+		return isParallelLines(x1, y1, x2, y2, x3, y3, x4, y4) && isCollinearPoints(x1, y1, x2, y2, x3, y3);
 	}
 
 	/**
@@ -2117,7 +2117,7 @@ public final class MathUtil {
 	 */
 	@Deprecated
 	public static boolean isCollinearLines(float x1, float y1, float z1, float x2, float y2, float z2, float x3, float y3, float z3, float x4, float y4, float z4) {
-		return (isParallelLines(x1, y1, z1, x2, y2, z2, x3, y3, z3, x4, y4, z4) && isCollinearPoints(x1, y1, z1, x2, y2, z2, x3, y3, z3));
+		return isParallelLines(x1, y1, z1, x2, y2, z2, x3, y3, z3, x4, y4, z4) && isCollinearPoints(x1, y1, z1, x2, y2, z2, x3, y3, z3);
 	}
 
 	/** Compute the zone where the point is against the given rectangle
@@ -2134,8 +2134,8 @@ public final class MathUtil {
 	 */
 	@Deprecated
 	public static int getCohenSutherlandCode(float px, float py, float rxmin, float rymin, float rxmax, float rymax) {
-		assert(rxmin<=rxmax);
-		assert(rymin<=rymax);
+		assert rxmin<=rxmax;
+		assert rymin<=rymax;
 		// initialised as being inside of clip window
 		int code = COHEN_SUTHERLAND_INSIDE;
 		if (px<rxmin) {


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:UselessParenthesesCheck - “ Useless parentheses around expressions should be removed to prevent any misunderstanding ”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
 Please let me know if you have any questions.
Fevzi Ozgul

<!---
@huboard:{"order":5.125,"milestone_order":43,"custom_state":""}
-->
