### PR TITLE
Fixing squid S2097  "equals(Object obj)" should test argument type

### DIFF
--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/PathElement2dfx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/PathElement2dfx.java
@@ -312,7 +312,15 @@ public abstract class PathElement2dfx implements PathElement2afp {
 		@Override
 		public boolean equals(Object obj) {
 			try {
-				final PathElement2afp elt = (PathElement2afp) obj;
+                if (obj == null) {
+                    return false;
+                }
+
+                if (this.getClass() != obj.getClass()) {
+                    return false;
+                }
+
+                final PathElement2afp elt = (PathElement2afp) obj;
 				return getType() == elt.getType()
 						&& getToX() == elt.getToX()
 						&& getToY() == elt.getToY();
@@ -447,6 +455,13 @@ public abstract class PathElement2dfx implements PathElement2afp {
 		@Override
 		public boolean equals(Object obj) {
 			try {
+                if (obj == null) {
+                    return false;
+                }
+
+                if (this.getClass() != obj.getClass()) {
+                    return false;
+                }
 				final PathElement2afp elt = (PathElement2afp) obj;
 				return getType() == elt.getType()
 						&& getToX() == elt.getToX()
@@ -605,6 +620,13 @@ public abstract class PathElement2dfx implements PathElement2afp {
 		@Override
 		public boolean equals(Object obj) {
 			try {
+                if (obj == null) {
+                    return false;
+                }
+
+                if (this.getClass() != obj.getClass()) {
+                    return false;
+                }
 				final PathElement2afp elt = (PathElement2afp) obj;
 				return getType() == elt.getType()
 						&& getToX() == elt.getToX()
@@ -812,6 +834,13 @@ public abstract class PathElement2dfx implements PathElement2afp {
 		@Override
 		public boolean equals(Object obj) {
 			try {
+                if (obj == null) {
+                    return false;
+                }
+
+                if (this.getClass() != obj.getClass()) {
+                    return false;
+                }
 				final PathElement2afp elt = (PathElement2afp) obj;
 				return getType() == elt.getType()
 						&& getToX() == elt.getToX()
@@ -1035,6 +1064,13 @@ public abstract class PathElement2dfx implements PathElement2afp {
 		@Override
 		public boolean equals(Object obj) {
 			try {
+                if (obj == null) {
+                    return false;
+                }
+
+                if (this.getClass() != obj.getClass()) {
+                    return false;
+                }
 				final PathElement2afp elt = (PathElement2afp) obj;
 				return getType() == elt.getType()
 						&& getToX() == elt.getToX()
@@ -1208,6 +1244,13 @@ public abstract class PathElement2dfx implements PathElement2afp {
 		@Override
 		public boolean equals(Object obj) {
 			try {
+                if (obj == null) {
+                    return false;
+                }
+
+                if (this.getClass() != obj.getClass()) {
+                    return false;
+                }
 				final PathElement2afp elt = (PathElement2afp) obj;
 				return getType() == elt.getType()
 						&& getToX() == elt.getToX()

--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/ifx/PathElement2ifx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/ifx/PathElement2ifx.java
@@ -312,6 +312,13 @@ public abstract class PathElement2ifx implements PathElement2ai {
 		@Override
 		public boolean equals(Object obj) {
 			try {
+                if (obj == null) {
+                    return false;
+                }
+
+                if (this.getClass() != obj.getClass()) {
+                    return false;
+                }
 				final PathElement2ai elt = (PathElement2ai) obj;
 				return getType() == elt.getType()
 						&& getToX() == elt.getToX()
@@ -448,6 +455,13 @@ public abstract class PathElement2ifx implements PathElement2ai {
 		@Override
 		public boolean equals(Object obj) {
 			try {
+                if (obj == null) {
+                    return false;
+                }
+
+                if (this.getClass() != obj.getClass()) {
+                    return false;
+                }
 				final PathElement2ai elt = (PathElement2ai) obj;
 				return getType() == elt.getType()
 						&& getToX() == elt.getToX()
@@ -603,6 +617,13 @@ public abstract class PathElement2ifx implements PathElement2ai {
 		@Override
 		public boolean equals(Object obj) {
 			try {
+                if (obj == null) {
+                    return false;
+                }
+
+                if (this.getClass() != obj.getClass()) {
+                    return false;
+                }
 				final PathElement2ai elt = (PathElement2ai) obj;
 				return getType() == elt.getType()
 						&& getToX() == elt.getToX()
@@ -806,6 +827,13 @@ public abstract class PathElement2ifx implements PathElement2ai {
 		@Override
 		public boolean equals(Object obj) {
 			try {
+                if (obj == null) {
+                    return false;
+                }
+
+                if (this.getClass() != obj.getClass()) {
+                    return false;
+                }
 				final PathElement2ai elt = (PathElement2ai) obj;
 				return getType() == elt.getType()
 						&& getToX() == elt.getToX()
@@ -1027,6 +1055,13 @@ public abstract class PathElement2ifx implements PathElement2ai {
 		@Override
 		public boolean equals(Object obj) {
 			try {
+                if (obj == null) {
+                    return false;
+                }
+
+                if (this.getClass() != obj.getClass()) {
+                    return false;
+                }
 				final PathElement2ai elt = (PathElement2ai) obj;
 				return getType() == elt.getType()
 						&& getToX() == elt.getToX()
@@ -1196,6 +1231,13 @@ public abstract class PathElement2ifx implements PathElement2ai {
 		@Override
 		public boolean equals(Object obj) {
 			try {
+                if (obj == null) {
+                    return false;
+                }
+
+                if (this.getClass() != obj.getClass()) {
+                    return false;
+                }
 				final PathElement2afp elt = (PathElement2afp) obj;
 				return getType() == elt.getType()
 						&& getToX() == elt.getToX()

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/d/PathElement2d.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/d/PathElement2d.java
@@ -849,6 +849,14 @@ public abstract class PathElement2d implements PathElement2afp {
 		@Override
 		public boolean equals(Object obj) {
 			try {
+                if (obj == null) {
+                    return false;
+                }
+
+                if (this.getClass() != obj.getClass()) {
+                    return false;
+                }
+
 				final PathElement2afp elt = (PathElement2afp) obj;
 				return getType() == elt.getType()
 						&& getToX() == elt.getToX()

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/i/PathElement2i.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/i/PathElement2i.java
@@ -821,6 +821,13 @@ public abstract class PathElement2i implements PathElement2ai {
 		@Override
 		public boolean equals(Object obj) {
 			try {
+                if (obj == null) {
+                    return false;
+                }
+
+                if (this.getClass() != obj.getClass()) {
+                    return false;
+                }
 				final PathElement2ai elt = (PathElement2ai) obj;
 				return getType() == elt.getType()
 						&& getToX() == elt.getToX()


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S2097 - “ ""equals(Object obj)"" should test argument type ”. 
This PR will remove 90 min TD.
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S2097
 Please let me know if you have any questions.
Fevzi Ozgul