### PR TITLE
Fixing squid: S128 Switch cases should end with an unconditional "break" statement

### DIFF
--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/d/Path2d.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/d/Path2d.java
@@ -715,6 +715,7 @@ public class Path2d
 			switch (this.types[j]) {
 			case MOVE_TO:
 				this.isMultipart = null;
+				break;
 				//$FALL-THROUGH$
 			case LINE_TO:
 				if (x == this.coords[i] && y == this.coords[i + 1]) {


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S128 - “Switch cases should end with an unconditional "break" statement ”. 
This PR will remove 20 min TD.
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S128
 Please let me know if you have any questions.
Fevzi Ozgul