### PR TITLE
Fixing squid: S2183  Ints and longs should not be shifted by more than their number of bits-1

### DIFF
--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/AbstractRectangularShape2dfx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/AbstractRectangularShape2dfx.java
@@ -301,7 +301,7 @@ public abstract class AbstractRectangularShape2dfx<IT extends AbstractRectangula
 		bits = 31 * bits + Double.doubleToLongBits(getMaxX());
 		bits = 31 * bits + Double.doubleToLongBits(getMaxY());
 		final int b = (int) bits;
-		return b ^ (b >> 32);
+		return b ^ (b >> 31);
 	}
 
 	@Pure

--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/Circle2dfx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/Circle2dfx.java
@@ -110,7 +110,7 @@ public class Circle2dfx
 		bits = 31 * bits + Double.doubleToLongBits(getY());
 		bits = 31 * bits + Double.doubleToLongBits(getRadius());
 		final int b = (int) bits;
-		return b ^ (b >> 32);
+		return b ^ (b >> 31);
 	}
 
 	@Pure

--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/MultiShape2dfx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/MultiShape2dfx.java
@@ -147,7 +147,7 @@ public class MultiShape2dfx<T extends Shape2dfx<?>> extends AbstractShape2dfx<Mu
 		long bits = 1;
 		bits = 31 * bits + this.elements.hashCode();
 		final int b = (int) bits;
-		return b ^ (b >> 32);
+		return b ^ (b >> 31);
 	}
 
 	@Pure

--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/OrientedRectangle2dfx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/OrientedRectangle2dfx.java
@@ -181,7 +181,7 @@ public class OrientedRectangle2dfx extends AbstractShape2dfx<OrientedRectangle2d
 		bits = 31 * bits + Double.doubleToLongBits(getSecondAxisY());
 		bits = 31 * bits + Double.doubleToLongBits(getSecondAxisExtent());
 		final int b = (int) bits;
-		return b ^ (b >> 32);
+		return b ^ (b >> 31);
 	}
 
 	@Pure

--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/Parallelogram2dfx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/Parallelogram2dfx.java
@@ -188,7 +188,7 @@ public class Parallelogram2dfx extends AbstractShape2dfx<Parallelogram2dfx>
 		bits = 31 * bits + Double.doubleToLongBits(getSecondAxisY());
 		bits = 31 * bits + Double.doubleToLongBits(getSecondAxisExtent());
 		final int b = (int) bits;
-		return b ^ (b >> 32);
+		return b ^ (b >> 31);
 	}
 
 	@Pure

--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/Rectangle2dfx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/Rectangle2dfx.java
@@ -130,7 +130,7 @@ public class Rectangle2dfx extends AbstractShape2dfx<Rectangle2dfx>
 		bits = 31 * bits + Double.doubleToLongBits(getMaxX());
 		bits = 31 * bits + Double.doubleToLongBits(getMaxY());
 		final int b = (int) bits;
-		return b ^ (b >> 32);
+		return b ^ (b >> 31);
 	}
 
 	@Pure

--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/RoundRectangle2dfx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/RoundRectangle2dfx.java
@@ -108,7 +108,7 @@ public class RoundRectangle2dfx extends AbstractRectangularShape2dfx<RoundRectan
 		bits = 31 * bits + Double.doubleToLongBits(getArcWidth());
 		bits = 31 * bits + Double.doubleToLongBits(getArcHeight());
 		final int b = (int) bits;
-		return b ^ (b >> 32);
+		return b ^ (b >> 31);
 	}
 
 	@Pure

--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/Segment2dfx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/Segment2dfx.java
@@ -115,7 +115,7 @@ public class Segment2dfx extends AbstractShape2dfx<Segment2dfx>
 		bits = 31 * bits + Double.doubleToLongBits(getX2());
 		bits = 31 * bits + Double.doubleToLongBits(getY2());
 		final int b = (int) bits;
-		return b ^ (b >> 32);
+		return b ^ (b >> 31);
 	}
 
 	@Pure

--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/Triangle2dfx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/Triangle2dfx.java
@@ -141,7 +141,7 @@ public class Triangle2dfx
 		bits = 31 * bits + Double.doubleToLongBits(getX3());
 		bits = 31 * bits + Double.doubleToLongBits(getY3());
 		final int b = (int) bits;
-		return b ^ (b >> 32);
+		return b ^ (b >> 31);
 	}
 
 	@Pure

--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/Tuple2dfx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/Tuple2dfx.java
@@ -150,7 +150,7 @@ public class Tuple2dfx<RT extends Tuple2dfx<? super RT>> implements Tuple2D<RT> 
 		bits = 31 * bits + Double.doubleToLongBits(getX());
 		bits = 31 * bits + Double.doubleToLongBits(getY());
 		final int b = (int) bits;
-		return b ^ (b >> 32);
+		return b ^ (b >> 31);
 	}
 
 	@Pure

--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/ifx/AbstractRectangularShape2ifx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/ifx/AbstractRectangularShape2ifx.java
@@ -262,7 +262,7 @@ public abstract class AbstractRectangularShape2ifx<IT extends AbstractRectangula
 		bits = 31 * bits + getMinY();
 		bits = 31 * bits + getMaxX();
 		bits = 31 * bits + getMaxY();
-		return bits ^ (bits >> 32);
+		return bits ^ (bits >> 31);
 	}
 
 	@Pure

--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/ifx/Circle2ifx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/ifx/Circle2ifx.java
@@ -106,7 +106,7 @@ public class Circle2ifx
 		bits = 31 * bits + getX();
 		bits = 31 * bits + getY();
 		bits = 31 * bits + getRadius();
-		return bits ^ (bits >> 32);
+		return bits ^ (bits >> 31);
 	}
 
 	@Pure

--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/ifx/MultiShape2ifx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/ifx/MultiShape2ifx.java
@@ -143,7 +143,7 @@ public class MultiShape2ifx<T extends Shape2ifx<?>> extends AbstractShape2ifx<Mu
 		long bits = 1;
 		bits = 31 * bits + this.elements.hashCode();
 		final int b = (int) bits;
-		return b ^ (b >> 32);
+		return b ^ (b >> 31);
 	}
 
 	@Pure

--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/ifx/PathElement2ifx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/ifx/PathElement2ifx.java
@@ -329,7 +329,7 @@ public abstract class PathElement2ifx implements PathElement2ai {
 			bits = 31 * bits + this.type.ordinal();
 			bits = 31 * bits + getToX();
 			bits = 31 * bits + getToY();
-			return bits ^ (bits >> 32);
+			return bits ^ (bits >> 31);
 		}
 
 		@Pure
@@ -469,7 +469,7 @@ public abstract class PathElement2ifx implements PathElement2ai {
 			bits = 31 * bits + getToY();
 			bits = 31 * bits + getFromX();
 			bits = 31 * bits + getFromY();
-			return bits ^ (bits >> 32);
+			return bits ^ (bits >> 31);
 		}
 
 		@Pure
@@ -628,7 +628,7 @@ public abstract class PathElement2ifx implements PathElement2ai {
 			bits = 31 * bits + getCtrlY1();
 			bits = 31 * bits + getFromX();
 			bits = 31 * bits + getFromY();
-			return bits ^ (bits >> 32);
+			return bits ^ (bits >> 31);
 		}
 
 		@Pure
@@ -835,7 +835,7 @@ public abstract class PathElement2ifx implements PathElement2ai {
 			bits = 31 * bits + getCtrlY2();
 			bits = 31 * bits + getFromX();
 			bits = 31 * bits + getFromY();
-			return bits ^ (bits >> 32);
+			return bits ^ (bits >> 31);
 		}
 
 		@Pure
@@ -1048,7 +1048,7 @@ public abstract class PathElement2ifx implements PathElement2ai {
 			bits = 31 * bits + getToY();
 			bits = 31 * bits + getFromX();
 			bits = 31 * bits + getFromY();
-			return bits ^ (bits >> 32);
+			return bits ^ (bits >> 31);
 		}
 
 		@Pure

--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/ifx/Rectangle2ifx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/ifx/Rectangle2ifx.java
@@ -275,7 +275,7 @@ public class Rectangle2ifx extends AbstractShape2ifx<Rectangle2ifx>
 		bits = 31 * bits + getMinY();
 		bits = 31 * bits + getMaxX();
 		bits = 31 * bits + getMaxY();
-		return bits ^ (bits >> 32);
+		return bits ^ (bits >> 31);
 	}
 
 	@Pure

--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/ifx/Segment2ifx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/ifx/Segment2ifx.java
@@ -113,7 +113,7 @@ public class Segment2ifx extends AbstractShape2ifx<Segment2ifx>
 		bits = 31 * bits + getY1();
 		bits = 31 * bits + getX2();
 		bits = 31 * bits + getY2();
-		return bits ^ (bits >> 32);
+		return bits ^ (bits >> 31);
 	}
 
 	@Pure

--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/ifx/Tuple2ifx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/ifx/Tuple2ifx.java
@@ -138,7 +138,7 @@ public class Tuple2ifx<RT extends Tuple2ifx<? super RT>> implements Tuple2D<RT> 
 		int bits = 1;
 		bits = 31 * bits + ix();
 		bits = 31 * bits + iy();
-		return bits ^ (bits >> 32);
+		return bits ^ (bits >> 31);
 	}
 
 	@Pure


### PR DESCRIPTION
 "This pull request is focused on resolving occurrences of Sonar rule 
 squid:S2183 - “Ints and longs should not be shifted by more than their number of bits-1”. 
This PR will remove 105 min TD.
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S2183
 Please let me know if you have any questions.
Fevzi Ozgul

<!---
@huboard:{"order":21.0,"milestone_order":63,"custom_state":""}
-->
