### PR TITLE
Fixing squid: S2160 Subclasses that add fields should override "equals"

### DIFF
--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/MultiShape2dfx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/MultiShape2dfx.java
@@ -246,7 +246,7 @@ public class MultiShape2dfx<T extends Shape2dfx<?>> extends AbstractShape2dfx<Mu
 			return false;
 		}
 
-		public int hasCode() {
+		public int hashCode() {
 			int hash = 1;
 			final int prime = 31;
 			hash = hash * prime + (int) (internalList.hashCode());

--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/MultiShape2dfx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/MultiShape2dfx.java
@@ -236,14 +236,21 @@ public class MultiShape2dfx<T extends Shape2dfx<?>> extends AbstractShape2dfx<Mu
 		}
 
 		public boolean equals(Object obj) {
-			if (! super.equals(obj)) {
+			if (!super.equals(obj)) {
 				return false;
 			}
-			InternalObservableList lObj = (InternalObservableList) obj;
+			final InternalObservableList lObj = (InternalObservableList) obj;
 			if (internalList.equals(lObj.internalList)) {
-				return true;
+				return internalList.equals(lObj.internalList);
 			}
 			return false;
+		}
+
+		public int hasCode() {
+			int hash = 1;
+			final int prime = 31;
+			hash = hash * prime + (int) (internalList.hashCode());
+			return hash;
 		}
 	}
 

--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/MultiShape2dfx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/MultiShape2dfx.java
@@ -235,6 +235,16 @@ public class MultiShape2dfx<T extends Shape2dfx<?>> extends AbstractShape2dfx<Mu
 			}
 		}
 
+		public boolean equals(Object obj) {
+			if (! super.equals(obj)) {
+				return false;
+			}
+			InternalObservableList lObj = (InternalObservableList) obj;
+			if (internalList.equals(lObj.internalList)) {
+				return true;
+			}
+			return false;
+		}
 	}
 
 }

--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/ifx/MultiShape2ifx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/ifx/MultiShape2ifx.java
@@ -230,7 +230,16 @@ public class MultiShape2ifx<T extends Shape2ifx<?>> extends AbstractShape2ifx<Mu
 				fireChange(new SimpleUpdateChange<>(position, this));
 			}
 		}
-
+		public boolean equals(Object obj) {
+			if (! super.equals(obj)) {
+				return false;
+			}
+			InternalObservableList lObj = (InternalObservableList) obj;
+			if (internalList.equals(lObj.internalList)) {
+				return true;
+			}
+			return false;
+		}
 	}
 
 }

--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/ifx/MultiShape2ifx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/ifx/MultiShape2ifx.java
@@ -242,7 +242,7 @@ public class MultiShape2ifx<T extends Shape2ifx<?>> extends AbstractShape2ifx<Mu
 			return false;
 		}
 
-		public int hasCode() {
+		public int hashCode() {
 			int hash = 1;
 			final int prime = 31;
 			hash = hash * prime + (int) (internalList.hashCode());

--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/ifx/MultiShape2ifx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/ifx/MultiShape2ifx.java
@@ -230,15 +230,23 @@ public class MultiShape2ifx<T extends Shape2ifx<?>> extends AbstractShape2ifx<Mu
 				fireChange(new SimpleUpdateChange<>(position, this));
 			}
 		}
+
 		public boolean equals(Object obj) {
-			if (! super.equals(obj)) {
+			if (!super.equals(obj)) {
 				return false;
 			}
-			InternalObservableList lObj = (InternalObservableList) obj;
+			final InternalObservableList lObj = (InternalObservableList) obj;
 			if (internalList.equals(lObj.internalList)) {
-				return true;
+				return internalList.equals(lObj.internalList);
 			}
 			return false;
+		}
+
+		public int hasCode() {
+			int hash = 1;
+			final int prime = 31;
+			hash = hash * prime + (int) (internalList.hashCode());
+			return hash;
 		}
 	}
 


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S2160 - “Subclasses that add fields should override ""equals""”. 
This PR will remove 60 min. TD.
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S2160
 Please let me know if you have any questions.
 Fevzi Ozgul

<!---
@huboard:{"milestone_order":65.0,"order":0.48828125,"custom_state":""}
-->
