### PR TITLE
Fixing squid: S1192 String literals should not be duplicated Fix 3

### DIFF
--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/afp/Path2afp.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/afp/Path2afp.java
@@ -61,7 +61,7 @@ public interface Path2afp<
 		B extends Rectangle2afp<?, ?, IE, P, V, B>>
 		extends Shape2afp<ST, IT, IE, P, V, B>, Path2D<ST, IT, PathIterator2afp<IE>, P, V, B> {
 
-    /**+
+    /**
      * Literal constant.
      */
     String COLL_NOT_NULL = "Collection must be not null";

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/afp/Path2afp.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/afp/Path2afp.java
@@ -61,6 +61,11 @@ public interface Path2afp<
 		B extends Rectangle2afp<?, ?, IE, P, V, B>>
 		extends Shape2afp<ST, IT, IE, P, V, B>, Path2D<ST, IT, PathIterator2afp<IE>, P, V, B> {
 
+    /**+
+     * Literal constant.
+     */
+    String COLL_NOT_NULL = "Collection must be not null";
+
 	/** Multiple of cubic & quad curve size.
 	 */
 	int GROW_SIZE = 24;
@@ -2062,7 +2067,8 @@ public interface Path2afp<
 			default:
 			}
 		}
-		if (foundOneControlPoint) {			box.setFromCorners(xmin, ymin, xmax, ymax);
+		if (foundOneControlPoint) {
+			box.setFromCorners(xmin, ymin, xmax, ymax);
 		} else {
 			box.clear();
 		}
@@ -3868,7 +3874,7 @@ public interface Path2afp<
 		@Pure
 		@Override
 		public boolean containsAll(Collection<?> collection) {
-			assert collection != null : "Collection must be not null"; //$NON-NLS-1$
+			assert collection != null : COLL_NOT_NULL; //$NON-NLS-1$
 			for (final Object obj : collection) {
 				if ((!(obj instanceof Point2D))
 						|| (!this.path.containsControlPoint((Point2D<?, ?>) obj))) {
@@ -3880,7 +3886,7 @@ public interface Path2afp<
 
 		@Override
 		public boolean addAll(Collection<? extends P> collection) {
-			assert collection != null : "Collection must be not null"; //$NON-NLS-1$
+			assert collection != null : COLL_NOT_NULL; //$NON-NLS-1$
 			boolean changed = false;
 			for (final P pts : collection) {
 				if (add(pts)) {
@@ -3892,7 +3898,7 @@ public interface Path2afp<
 
 		@Override
 		public boolean removeAll(Collection<?> collection) {
-			assert collection != null : "Collection must be not null"; //$NON-NLS-1$
+			assert collection != null : COLL_NOT_NULL; //$NON-NLS-1$
 			boolean changed = false;
 			for (final Object obj : collection) {
 				if (obj instanceof Point2D) {

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/afp/Path2afp.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/afp/Path2afp.java
@@ -38,7 +38,6 @@ import org.arakhne.afc.math.geometry.d2.Vector2D;
 import org.arakhne.afc.math.geometry.d2.afp.Circle2afp.AbstractCirclePathIterator;
 
 /** Fonctional interface that represented a 2D path on a plane.
- *
  * @param <ST> is the type of the general implementation.
  * @param <IT> is the type of the implementation of this shape.
  * @param <IE> is the type of the path elements.
@@ -60,7 +59,6 @@ public interface Path2afp<
 		V extends Vector2D<? super V, ? super P>,
 		B extends Rectangle2afp<?, ?, IE, P, V, B>>
 		extends Shape2afp<ST, IT, IE, P, V, B>, Path2D<ST, IT, PathIterator2afp<IE>, P, V, B> {
-
     /**
      * Literal constant.
      */
@@ -89,7 +87,6 @@ public interface Path2afp<
 	 * The path must start with a SEG_MOVETO, otherwise an exception is
 	 * thrown.
 	 * The caller must check r[xy]{min, max} for NaN values.
-	 *
 	 * @param crossings is the initial value for crossing.
 	 * @param iterator is the iterator on the path elements.
 	 * @param shadow is the description of the shape to project to the right.
@@ -255,7 +252,6 @@ public interface Path2afp<
 	 * {@link PathIterator2D#isCurved()} of {@code pi} is replying
 	 * <code>false</code>.
 	 * {@link #getClosestPointTo(Point2D)} avoids this restriction.
-	 *
 	 * @param pi is the iterator on the elements of the path.
 	 * @param x x coordinate of the point.
 	 * @param y y coordinate of the point.
@@ -347,7 +343,6 @@ public interface Path2afp<
 	 * {@link PathIterator2D#isCurved()} of {@code pi} is replying
 	 * <code>false</code>.
 	 * {@link #getFarthestPointTo(Point2D)} avoids this restriction.
-	 *
 	 * @param pi is the iterator on the elements of the path.
 	 * @param x x coordinate of the point.
 	 * @param y y coordinate of the point.
@@ -427,7 +422,6 @@ public interface Path2afp<
 	 * <p>This method provides a basic facility for implementors of
 	 * the {@link Shape2afp} interface to implement support for the
 	 * {@link Shape2afp#contains(Rectangle2afp)} method.
-	 *
 	 * @param pi the specified {@code PathIterator2f}
 	 * @param rx the lowest corner of the rectangle.
 	 * @param ry the lowest corner of the rectangle.
@@ -457,7 +451,6 @@ public interface Path2afp<
 	 * Tests if the interior of the specified {@link PathIterator2afp}
 	 * intersects the interior of a specified set of rectangular
 	 * coordinates.
-	 *
 	 * @param pi the specified {@link PathIterator2afp}.
 	 * @param x the specified X coordinate of the rectangle.
 	 * @param y the specified Y coordinate of the rectangle.
@@ -670,7 +663,6 @@ public interface Path2afp<
 	/**
 	 * Calculates the number of times the given path
 	 * crosses the given ellipse extending to the right.
-	 *
 	 * @param crossings is the initial value for crossing.
 	 * @param iterator is the description of the path.
 	 * @param ex is the first point of the ellipse.
@@ -844,7 +836,6 @@ public interface Path2afp<
 	/**
 	 * Calculates the number of times the given path
 	 * crosses the given ellipse extending to the right.
-	 *
 	 * @param crossings is the initial value for crossing.
 	 * @param iterator is the description of the path.
 	 * @param x1 is the first corner of the rectangle.
@@ -1373,7 +1364,6 @@ public interface Path2afp<
 	 * The path must start with a SEG_MOVETO, otherwise an exception is
 	 * thrown.
 	 * The caller must check r[xy]{min, max} for NaN values.
-	 *
 	 * @param crossings is the initial value for crossing.
 	 * @param iterator is the iterator on the path elements.
 	 * @param rxmin is the first corner of the rectangle.
@@ -1750,7 +1740,6 @@ public interface Path2afp<
 	 * The box fits the drawn lines and the drawn curves. The control points of the
 	 * curves may be outside the output box. For obtaining the bounding box
 	 * of the path's points, use {@link #computeControlPointBoundingBox(PathIterator2afp, Rectangle2afp)}.
-	 *
 	 * @param iterator the iterator on the path elements.
 	 * @param box the box to set.
 	 * @return <code>true</code> if a drawable element was found.

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/afp/RoundRectangle2afp.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/afp/RoundRectangle2afp.java
@@ -56,8 +56,7 @@ public interface RoundRectangle2afp<
 		V extends Vector2D<? super V, ? super P>,
 		B extends Rectangle2afp<?, ?, IE, P, V, B>>
 		extends RectangularShape2afp<ST, IT, IE, P, V, B> {
-
-    /**
+	/**
      * Literal constant.
      */
 	String ROUND_RECTANGLE_ARC_HEIGHT = "Round rectangle arc height must be positive or zero";

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/afp/RoundRectangle2afp.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/afp/RoundRectangle2afp.java
@@ -57,18 +57,21 @@ public interface RoundRectangle2afp<
 		B extends Rectangle2afp<?, ?, IE, P, V, B>>
 		extends RectangularShape2afp<ST, IT, IE, P, V, B> {
 
-    /**+
+    /**
      * Literal constant.
      */
 	String ROUND_RECTANGLE_ARC_HEIGHT = "Round rectangle arc height must be positive or zero";
-    /**+
+
+    /**
      * Literal constant.
      */
     String ROUND_RECTANGLE_ARC_WIDTH = "Round rectangle arc width must be positive or zero";
+
     /**+
      * Literal constant.
      */
     String RY1_LOWER_OR_EQUAL_RY2 = "ry1 must be lower or equal ry2";
+
     /**+
      * Literal constant.
      */

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/afp/RoundRectangle2afp.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/afp/RoundRectangle2afp.java
@@ -57,6 +57,23 @@ public interface RoundRectangle2afp<
 		B extends Rectangle2afp<?, ?, IE, P, V, B>>
 		extends RectangularShape2afp<ST, IT, IE, P, V, B> {
 
+    /**+
+     * Literal constant.
+     */
+	String ROUND_RECTANGLE_ARC_HEIGHT = "Round rectangle arc height must be positive or zero";
+    /**+
+     * Literal constant.
+     */
+    String ROUND_RECTANGLE_ARC_WIDTH = "Round rectangle arc width must be positive or zero";
+    /**+
+     * Literal constant.
+     */
+    String RY1_LOWER_OR_EQUAL_RY2 = "ry1 must be lower or equal ry2";
+    /**+
+     * Literal constant.
+     */
+    String RX1_LOWER_OR_EQUAL_RX2 = "rx1 must be lower or equal rx2";
+
 	/** Replies if a rectangle is inside in the round rectangle.
 	 *
 	 * @param rx1 is the lowest corner of the round rectangle.
@@ -78,8 +95,8 @@ public interface RoundRectangle2afp<
 			double awidth, double aheight, double rx2, double ry2, double rwidth2, double rheight2) {
 		assert rwidth1 >= 0. : "Round rectangle width must be positive or zero"; //$NON-NLS-1$
 		assert rheight1 >= 0. : "Round rectangle height must be positive or zero"; //$NON-NLS-1$
-		assert awidth >= 0. : "Round rectangle arc width must be positive or zero"; //$NON-NLS-1$
-		assert aheight >= 0. : "Round rectangle arc height must be positive or zero"; //$NON-NLS-1$
+		assert awidth >= 0. : ROUND_RECTANGLE_ARC_WIDTH; //$NON-NLS-1$
+		assert aheight >= 0. : ROUND_RECTANGLE_ARC_HEIGHT; //$NON-NLS-1$
 		assert rwidth2 >= 0. : "Rectangle width must be positive or zero"; //$NON-NLS-1$
 		assert rheight2 >= 0. : "Rectangle height must be positive or zero"; //$NON-NLS-1$
 		final double rcx1 = rx1 + rwidth1 / 2;
@@ -119,8 +136,8 @@ public interface RoundRectangle2afp<
 			double awidth, double aheight, double px, double py) {
 		assert rwidth >= 0. : "Round rectangle width must be positive or zero"; //$NON-NLS-1$
 		assert rheight >= 0. : "Round rectangle height must be positive or zero"; //$NON-NLS-1$
-		assert awidth >= 0. : "Round rectangle arc width must be positive or zero"; //$NON-NLS-1$
-		assert aheight >= 0. : "Round rectangle arc height must be positive or zero"; //$NON-NLS-1$
+		assert awidth >= 0. : ROUND_RECTANGLE_ARC_WIDTH; //$NON-NLS-1$
+		assert aheight >= 0. : ROUND_RECTANGLE_ARC_HEIGHT; //$NON-NLS-1$
 		if (rwidth <= 0 && rheight <= 0) {
 			return rx == px && ry == py;
 		}
@@ -183,10 +200,10 @@ public interface RoundRectangle2afp<
 		"checkstyle:npathcomplexity", "checkstyle:nestedifdepth"})
 	static boolean intersectsRoundRectangleSegment(double rx1, double ry1, double rx2, double ry2,
 			double aw, double ah, double sx1, double sy1, double sx2, double sy2) {
-		assert rx1 <= rx2 : "rx1 must be lower or equal rx2"; //$NON-NLS-1$
-		assert ry1 <= ry2 : "ry1 must be lower or equal ry2"; //$NON-NLS-1$
-		assert aw >= 0. : "Round rectangle arc width must be positive or zero"; //$NON-NLS-1$
-		assert ah >= 0. : "Round rectangle arc height must be positive or zero"; //$NON-NLS-1$
+		assert rx1 <= rx2 :  RX1_LOWER_OR_EQUAL_RX2; //$NON-NLS-1$
+		assert ry1 <= ry2 :  RY1_LOWER_OR_EQUAL_RY2; //$NON-NLS-1$
+		assert aw >= 0. : ROUND_RECTANGLE_ARC_WIDTH; //$NON-NLS-1$
+		assert ah >= 0. : ROUND_RECTANGLE_ARC_HEIGHT; //$NON-NLS-1$
 		double segmentX1 = sx1;
 		double segmentY1 = sy1;
 		double segmentX2 = sx2;
@@ -397,10 +414,10 @@ public interface RoundRectangle2afp<
 	static boolean intersectsRoundRectangleCircle(double rx1, double ry1, double rx2,
 			double ry2, double aw, double ah,
 			double cx, double cy, double radius) {
-		assert rx1 <= rx2 : "rx1 must be lower or equal rx2"; //$NON-NLS-1$
-		assert ry1 <= ry2 : "ry1 must be lower or equal ry2"; //$NON-NLS-1$
-		assert aw >= 0. : "Round rectangle arc width must be positive or zero"; //$NON-NLS-1$
-		assert ah >= 0. : "Round rectangle arc height must be positive or zero"; //$NON-NLS-1$
+		assert rx1 <= rx2 :  RX1_LOWER_OR_EQUAL_RX2; //$NON-NLS-1$
+		assert ry1 <= ry2 :  RY1_LOWER_OR_EQUAL_RY2; //$NON-NLS-1$
+		assert aw >= 0. : ROUND_RECTANGLE_ARC_WIDTH; //$NON-NLS-1$
+		assert ah >= 0. : ROUND_RECTANGLE_ARC_HEIGHT; //$NON-NLS-1$
 		assert radius >= 0. : "Circle radius must be positive or zero"; //$NON-NLS-1$
 
 		final double rInnerMinX = rx1 + aw;
@@ -452,8 +469,8 @@ public interface RoundRectangle2afp<
 			double r2x1, double r2y1, double r2x2, double r2y2) {
 		assert r1x1 <= r1x2 : "r1x1 must be lower or equal r1x2"; //$NON-NLS-1$
 		assert r1y1 <= r1y2 : "r1y1 must be lower or equal r1y2"; //$NON-NLS-1$
-		assert r1aw >= 0. : "Round rectangle arc width must be positive or zero"; //$NON-NLS-1$
-		assert r1ah >= 0. : "Round rectangle arc height must be positive or zero"; //$NON-NLS-1$
+		assert r1aw >= 0. : ROUND_RECTANGLE_ARC_WIDTH; //$NON-NLS-1$
+		assert r1ah >= 0. : ROUND_RECTANGLE_ARC_HEIGHT; //$NON-NLS-1$
 		assert r2x1 <= r2x2 : "r2x1 must be lower or equal r2x2"; //$NON-NLS-1$
 		assert r2y1 <= r2y2 : "r2y1 must be lower or equal r2y2"; //$NON-NLS-1$
 		if (Rectangle2afp.intersectsRectangleRectangle(r1x1, r1y1, r1x2, r1y2, r2x1, r2y1, r2x2, r2y2)) {
@@ -517,10 +534,10 @@ public interface RoundRectangle2afp<
 	static boolean intersectsRoundRectangleEllipse(double rx1, double ry1, double rx2,
 			double ry2, double aw, double ah,
 			double ex, double ey, double ew, double eh) {
-		assert rx1 <= rx2 : "rx1 must be lower or equal rx2"; //$NON-NLS-1$
-		assert ry1 <= ry2 : "ry1 must be lower or equal ry2"; //$NON-NLS-1$
-		assert aw >= 0. : "Round rectangle arc width must be positive or zero"; //$NON-NLS-1$
-		assert ah >= 0. : "Round rectangle arc height must be positive or zero"; //$NON-NLS-1$
+		assert rx1 <= rx2 :  RX1_LOWER_OR_EQUAL_RX2; //$NON-NLS-1$
+		assert ry1 <= ry2 :  RY1_LOWER_OR_EQUAL_RY2; //$NON-NLS-1$
+		assert aw >= 0. : ROUND_RECTANGLE_ARC_WIDTH; //$NON-NLS-1$
+		assert ah >= 0. : ROUND_RECTANGLE_ARC_HEIGHT; //$NON-NLS-1$
 		assert ew >= 0. : "Ellipse width must be positive or zero"; //$NON-NLS-1$
 		assert eh >= 0. : "Ellipse height must be positive or zero"; //$NON-NLS-1$
 

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/afp/RoundRectangle2afp.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/afp/RoundRectangle2afp.java
@@ -66,12 +66,12 @@ public interface RoundRectangle2afp<
      */
     String ROUND_RECTANGLE_ARC_WIDTH = "Round rectangle arc width must be positive or zero";
 
-    /**+
+    /**
      * Literal constant.
      */
     String RY1_LOWER_OR_EQUAL_RY2 = "ry1 must be lower or equal ry2";
 
-    /**+
+    /**
      * Literal constant.
      */
     String RX1_LOWER_OR_EQUAL_RX2 = "rx1 must be lower or equal rx2";

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/ai/Path2ai.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/ai/Path2ai.java
@@ -60,8 +60,7 @@ public interface Path2ai<
 		V extends Vector2D<? super V, ? super P>,
 		B extends Rectangle2ai<?, ?, IE, P, V, B>>
 		extends Shape2ai<ST, IT, IE, P, V, B>, Path2D<ST, IT, PathIterator2ai<IE>, P, V, B> {
-
-    /** Literal constant.
+	/** Literal constant.
      */
 	String COLL_NOT_NULL = "Collection must not be  null";
 

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/ai/Path2ai.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/ai/Path2ai.java
@@ -61,6 +61,11 @@ public interface Path2ai<
 		B extends Rectangle2ai<?, ?, IE, P, V, B>>
 		extends Shape2ai<ST, IT, IE, P, V, B>, Path2D<ST, IT, PathIterator2ai<IE>, P, V, B> {
 
+    /**+
+     * Literal constant.
+     */
+	String COLL_NOT_NULL = "Collection must not be  null";
+
 	/** Multiple of cubic & quad curve size.
 	 */
 	int GROW_SIZE = 24;
@@ -2752,7 +2757,7 @@ public interface Path2ai<
 
 		@Override
 		public boolean containsAll(Collection<?> collection) {
-			assert collection != null : "Collection must not be null"; //$NON-NLS-1$
+			assert collection != null : COLL_NOT_NULL; //$NON-NLS-1$
 			for (final Object obj : collection) {
 				if ((!(obj instanceof Point2D))
 						|| (!this.path.contains((Point2D<?, ?>) obj))) {
@@ -2764,7 +2769,7 @@ public interface Path2ai<
 
 		@Override
 		public boolean addAll(Collection<? extends P> collection) {
-			assert collection != null : "Collection must not be null"; //$NON-NLS-1$
+			assert collection != null : COLL_NOT_NULL; //$NON-NLS-1$
 			boolean changed = false;
 			for (final P pts : collection) {
 				if (add(pts)) {
@@ -2776,7 +2781,7 @@ public interface Path2ai<
 
 		@Override
 		public boolean removeAll(Collection<?> collection) {
-			assert collection != null : "Collection must not be null"; //$NON-NLS-1$
+			assert collection != null : COLL_NOT_NULL; //$NON-NLS-1$
 			boolean changed = false;
 			for (final Object obj : collection) {
 				if (obj instanceof Point2D) {

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/ai/Path2ai.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/ai/Path2ai.java
@@ -61,8 +61,7 @@ public interface Path2ai<
 		B extends Rectangle2ai<?, ?, IE, P, V, B>>
 		extends Shape2ai<ST, IT, IE, P, V, B>, Path2D<ST, IT, PathIterator2ai<IE>, P, V, B> {
 
-    /**+
-     * Literal constant.
+    /** Literal constant.
      */
 	String COLL_NOT_NULL = "Collection must not be  null";
 

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/d/PathElement2d.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/d/PathElement2d.java
@@ -37,6 +37,10 @@ import org.arakhne.afc.math.geometry.d2.afp.PathElement2afp;
 public abstract class PathElement2d implements PathElement2afp {
 
 	private static final long serialVersionUID = -9217295344283468162L;
+    /**+
+     * Literal constant.
+     */
+    private static final String ARRAY_SIZE_SMALL = "Array size is too small";
 
 	/** Type of the element.
 	 */
@@ -199,7 +203,7 @@ public abstract class PathElement2d implements PathElement2afp {
 		@Override
 		public void toArray(int[] array) {
 			assert array != null : "Array must be not null"; //$NON-NLS-1$
-			assert array.length >= 2 : "Array size is too small"; //$NON-NLS-1$
+			assert array.length >= 2 : ARRAY_SIZE_SMALL; //$NON-NLS-1$
 			array[0] = (int) this.toX;
 			array[1] = (int) this.toY;
 		}
@@ -207,7 +211,7 @@ public abstract class PathElement2d implements PathElement2afp {
 		@Override
 		public void toArray(double[] array) {
 			assert array != null : "Array must be not null"; //$NON-NLS-1$
-			assert array.length >= 2 : "Array size is too small"; //$NON-NLS-1$
+			assert array.length >= 2 : ARRAY_SIZE_SMALL; //$NON-NLS-1$
 			array[0] = this.toX;
 			array[1] = this.toY;
 		}
@@ -315,7 +319,7 @@ public abstract class PathElement2d implements PathElement2afp {
 		@Override
 		public void toArray(int[] array) {
 			assert array != null : "Array must be not null"; //$NON-NLS-1$
-			assert array.length >= 2 : "Array size is too small"; //$NON-NLS-1$
+			assert array.length >= 2 : ARRAY_SIZE_SMALL; //$NON-NLS-1$
 			array[0] = (int) this.toX;
 			array[1] = (int) this.toY;
 		}
@@ -323,7 +327,7 @@ public abstract class PathElement2d implements PathElement2afp {
 		@Override
 		public void toArray(double[] array) {
 			assert array != null : "Array must be not null"; //$NON-NLS-1$
-			assert array.length >= 2 : "Array size is too small"; //$NON-NLS-1$
+			assert array.length >= 2 : ARRAY_SIZE_SMALL; //$NON-NLS-1$
 			array[0] = this.toX;
 			array[1] = this.toY;
 		}
@@ -446,7 +450,7 @@ public abstract class PathElement2d implements PathElement2afp {
 		@Override
 		public void toArray(int[] array) {
 			assert array != null : "Array must be not null"; //$NON-NLS-1$
-			assert array.length >= 4 : "Array size is too small"; //$NON-NLS-1$
+			assert array.length >= 4 : ARRAY_SIZE_SMALL; //$NON-NLS-1$
 			array[0] = (int) this.ctrlX;
 			array[1] = (int) this.ctrlY;
 			array[2] = (int) this.toX;
@@ -456,7 +460,7 @@ public abstract class PathElement2d implements PathElement2afp {
 		@Override
 		public void toArray(double[] array) {
 			assert array != null : "Array must be not null"; //$NON-NLS-1$
-			assert array.length >= 4 : "Array size is too small"; //$NON-NLS-1$
+			assert array.length >= 4 : ARRAY_SIZE_SMALL; //$NON-NLS-1$
 			array[0] = this.ctrlX;
 			array[1] = this.ctrlY;
 			array[2] = this.toX;
@@ -608,7 +612,7 @@ public abstract class PathElement2d implements PathElement2afp {
 		@Override
 		public void toArray(int[] array) {
 			assert array != null : "Array must be not null"; //$NON-NLS-1$
-			assert array.length >= 6 : "Array size is too small"; //$NON-NLS-1$
+			assert array.length >= 6 : ARRAY_SIZE_SMALL; //$NON-NLS-1$
 			array[0] = (int) this.ctrlX1;
 			array[1] = (int) this.ctrlY1;
 			array[2] = (int) this.ctrlX2;
@@ -620,7 +624,7 @@ public abstract class PathElement2d implements PathElement2afp {
 		@Override
 		public void toArray(double[] array) {
 			assert array != null : "Array must be not null"; //$NON-NLS-1$
-			assert array.length >= 6 : "Array size is too small"; //$NON-NLS-1$
+			assert array.length >= 6 : ARRAY_SIZE_SMALL; //$NON-NLS-1$
 			array[0] = this.ctrlX1;
 			array[1] = this.ctrlY1;
 			array[2] = this.ctrlX2;
@@ -756,7 +760,7 @@ public abstract class PathElement2d implements PathElement2afp {
 		@Override
 		public void toArray(int[] array) {
 			assert array != null : "Array must be not null"; //$NON-NLS-1$
-			assert array.length >= 2 : "Array size is too small"; //$NON-NLS-1$
+			assert array.length >= 2 : ARRAY_SIZE_SMALL; //$NON-NLS-1$
 			array[0] = (int) this.toX;
 			array[1] = (int) this.toY;
 		}
@@ -764,7 +768,7 @@ public abstract class PathElement2d implements PathElement2afp {
 		@Override
 		public void toArray(double[] array) {
 			assert array != null : "Array must be not null"; //$NON-NLS-1$
-			assert array.length >= 2 : "Array size is too small"; //$NON-NLS-1$
+			assert array.length >= 2 : ARRAY_SIZE_SMALL; //$NON-NLS-1$
 			array[0] = this.toX;
 			array[1] = this.toY;
 		}
@@ -898,7 +902,7 @@ public abstract class PathElement2d implements PathElement2afp {
 		@Override
 		public void toArray(int[] array) {
 			assert array != null : "Array must be not null"; //$NON-NLS-1$
-			assert array.length >= 2 : "Array size is too small"; //$NON-NLS-1$
+			assert array.length >= 2 : ARRAY_SIZE_SMALL; //$NON-NLS-1$
 			array[0] = (int) this.toX;
 			array[1] = (int) this.toY;
 		}
@@ -906,7 +910,7 @@ public abstract class PathElement2d implements PathElement2afp {
 		@Override
 		public void toArray(double[] array) {
 			assert array != null : "Array must be not null"; //$NON-NLS-1$
-			assert array.length >= 2 : "Array size is too small"; //$NON-NLS-1$
+			assert array.length >= 2 : ARRAY_SIZE_SMALL; //$NON-NLS-1$
 			array[0] = this.toX;
 			array[1] = this.toY;
 		}

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/d/PathElement2d.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/d/PathElement2d.java
@@ -36,939 +36,940 @@ import org.arakhne.afc.math.geometry.d2.afp.PathElement2afp;
  */
 public abstract class PathElement2d implements PathElement2afp {
 
-	private static final long serialVersionUID = -9217295344283468162L;
-    /**+
+    private static final long serialVersionUID = -9217295344283468162L;
+
+    /**
      * Literal constant.
      */
     private static final String ARRAY_SIZE_SMALL = "Array size is too small";
 
-	/** Type of the element.
-	 */
-	protected final PathElementType type;
-
-	/** Target point.
-	 */
-	protected final double toX;
-
-	/** Target point.
-	 */
-	protected final double toY;
-
-	/**
-	 * @param type is the type of the element.
-	 * @param tox the x coordinate of the target point.
-	 * @param toy the x coordinate of the target point.
-	 */
-	PathElement2d(PathElementType type, double tox, double toy) {
-		assert type != null : "Path element type must be not null"; //$NON-NLS-1$
-		this.type = type;
-		this.toX = tox;
-		this.toY = toy;
-	}
-
-	@Pure
-	@Override
-	public abstract boolean equals(Object obj);
-
-	@Pure
-	@Override
-	public abstract int hashCode();
-
-	@Override
-	@Pure
-	public final double getToX() {
-		return this.toX;
-	}
-
-	@Override
-	@Pure
-	public final double getToY() {
-		return this.toY;
-	}
-
-	@Pure
-	@Override
-	public final PathElementType getType() {
-		return this.type;
-	}
-
-	@Override
-	public double getCtrlX1() {
-		return 0;
-	}
-
-	@Override
-	public double getCtrlY1() {
-		return 0;
-	}
-
-	@Override
-	public double getCtrlX2() {
-		return 0;
-	}
-
-	@Override
-	public double getCtrlY2() {
-		return 0;
-	}
-
-	@Override
-	public double getRadiusX() {
-		return 0;
-	}
-
-	@Override
-	public double getRadiusY() {
-		return 0;
-	}
-
-	@Override
-	public double getRotationX() {
-		return 0;
-	}
-
-	@Override
-	public boolean getSweepFlag() {
-		return false;
-	}
-
-	@Override
-	public boolean getLargeArcFlag() {
-		return false;
-	}
-
-	/** Copy the coords into an array, except the source point.
-	 *
-	 * @return the array of the points, except the source point.
-	 */
-	@Pure
-	public abstract double[] toArray();
-
-	/** An element of the path that represents a <code>MOVE_TO</code>.
-	 *
-	 * @author $Author: sgalland$
-	 * @version $FullVersion$
-	 * @mavengroupid $GroupId$
-	 * @mavenartifactid $ArtifactId$
-	 * @since 13.0
-	 */
-	static class MovePathElement2d extends PathElement2d {
-
-		private static final long serialVersionUID = -399575136145167775L;
-
-		/**
-		 * @param tox x coordinate of the target point.
-		 * @param toy y coordinate of the target point.
-		 */
-		MovePathElement2d(double tox, double toy) {
-			super(PathElementType.MOVE_TO, tox, toy);
-		}
-
-		@Pure
-		@Override
-		public boolean equals(Object obj) {
-			try {
-				final PathElement2afp elt = (PathElement2afp) obj;
-				return getType() == elt.getType()
-						&& getToX() == elt.getToX()
-						&& getToY() == elt.getToY();
-			} catch (Throwable exception) {
-				//
-			}
-			return false;
-		}
-
-		@Pure
-		@Override
-		public int hashCode() {
-			long bits = 1L;
-			bits = 31L * bits + this.type.ordinal();
-			bits = 31L * bits + Double.doubleToLongBits(getToX());
-			bits = 31L * bits + Double.doubleToLongBits(getToY());
-			return (int) (bits ^ (bits >> 32));
-		}
-
-		@Pure
-		@Override
-		public boolean isEmpty() {
-			return true;
-		}
-
-		@Pure
-		@Override
-		public boolean isDrawable() {
-			return false;
-		}
-
-		@Override
-		public void toArray(int[] array) {
-			assert array != null : "Array must be not null"; //$NON-NLS-1$
-			assert array.length >= 2 : ARRAY_SIZE_SMALL; //$NON-NLS-1$
-			array[0] = (int) this.toX;
-			array[1] = (int) this.toY;
-		}
-
-		@Override
-		public void toArray(double[] array) {
-			assert array != null : "Array must be not null"; //$NON-NLS-1$
-			assert array.length >= 2 : ARRAY_SIZE_SMALL; //$NON-NLS-1$
-			array[0] = this.toX;
-			array[1] = this.toY;
-		}
-
-		@Pure
-		@Override
-		public double[] toArray() {
-			return new double[] {this.toX, this.toY};
-		}
-
-		@Pure
-		@Override
-		public String toString() {
-			return "MOVE(" //$NON-NLS-1$
-					+ this.toX + "x" //$NON-NLS-1$
-					+ this.toY + ")"; //$NON-NLS-1$
-		}
-
-		@Override
-		public double getFromX() {
-			return 0.;
-		}
-
-		@Override
-		public double getFromY() {
-			return 0.;
-		}
-
-	}
-
-	/** An element of the path that represents a <code>LINE_TO</code>.
-	 *
-	 * @author $Author: sgalland$
-	 * @version $FullVersion$
-	 * @mavengroupid $GroupId$
-	 * @mavenartifactid $ArtifactId$
-	 * @since 13.0
-	 */
-	static class LinePathElement2d extends PathElement2d {
-
-		private static final long serialVersionUID = 8423845888008307447L;
-
-		private final double fromX;
-
-		private final double fromY;
-
-		private Boolean isEmpty;
-
-		/**
-		 * @param fromx x coordinate of the origin point.
-		 * @param fromy y coordinate of the origin point.
-		 * @param tox x coordinate of the target point.
-		 * @param toy y coordinate of the target point.
-		 */
-		LinePathElement2d(double fromx, double fromy, double tox, double toy) {
-			super(PathElementType.LINE_TO, tox, toy);
-			this.fromX = fromx;
-			this.fromY = fromy;
-		}
-
-		@Pure
-		@Override
-		public boolean equals(Object obj) {
-			try {
-				final PathElement2afp elt = (PathElement2afp) obj;
-				return getType() == elt.getType()
-						&& getToX() == elt.getToX()
-						&& getToY() == elt.getToY()
-						&& getFromX() == elt.getFromX()
-						&& getFromY() == elt.getFromY();
-			} catch (Throwable exception) {
-				//
-			}
-			return false;
-		}
-
-		@Pure
-		@Override
-		public int hashCode() {
-			long bits = 1L;
-			bits = 31L * bits + this.type.ordinal();
-			bits = 31L * bits + Double.doubleToLongBits(getToX());
-			bits = 31L * bits + Double.doubleToLongBits(getToY());
-			bits = 31L * bits + Double.doubleToLongBits(getFromX());
-			bits = 31L * bits + Double.doubleToLongBits(getFromY());
-			return (int) (bits ^ (bits >> 32));
-		}
-
-		@Pure
-		@Override
-		public boolean isEmpty() {
-			if (this.isEmpty == null) {
-				this.isEmpty = MathUtil.isEpsilonEqual(this.fromX, this.toX)
-						&& MathUtil.isEpsilonEqual(this.fromY, this.toY);
-			}
-			return this.isEmpty.booleanValue();
-		}
-
-		@Pure
-		@Override
-		public boolean isDrawable() {
-			return !isEmpty();
-		}
-
-		@Override
-		public void toArray(int[] array) {
-			assert array != null : "Array must be not null"; //$NON-NLS-1$
-			assert array.length >= 2 : ARRAY_SIZE_SMALL; //$NON-NLS-1$
-			array[0] = (int) this.toX;
-			array[1] = (int) this.toY;
-		}
-
-		@Override
-		public void toArray(double[] array) {
-			assert array != null : "Array must be not null"; //$NON-NLS-1$
-			assert array.length >= 2 : ARRAY_SIZE_SMALL; //$NON-NLS-1$
-			array[0] = this.toX;
-			array[1] = this.toY;
-		}
-
-		@Pure
-		@Override
-		public double[] toArray() {
-			return new double[] {this.toX, this.toY};
-		}
-
-		@Pure
-		@Override
-		public String toString() {
-			return "LINE(" //$NON-NLS-1$
-					+ this.toX + "x" //$NON-NLS-1$
-					+ this.toY + ")"; //$NON-NLS-1$
-		}
-
-		@Override
-		public double getFromX() {
-			return this.fromX;
-		}
-
-		@Override
-		public double getFromY() {
-			return this.fromY;
-		}
-
-	}
-
-	/** An element of the path that represents a <code>QUAD_TO</code>.
-	 *
-	 * @author $Author: sgalland$
-	 * @version $FullVersion$
-	 * @mavengroupid $GroupId$
-	 * @mavenartifactid $ArtifactId$
-	 * @since 13.0
-	 */
-	@SuppressWarnings("checkstyle:magicnumber")
-	static class QuadPathElement2d extends PathElement2d {
-
-		private static final long serialVersionUID = 6092391345111872481L;
-
-		private final double fromX;
-
-		private final double fromY;
-
-		private final double ctrlX;
-
-		private final double ctrlY;
-
-		private Boolean isEmpty;
-
-		/**
-		 * @param fromx x coordinate of the origin point.
-		 * @param fromy y coordinate of the origin point.
-		 * @param ctrlx x coordinate of the control point.
-		 * @param ctrly y coordinate of the control point.
-		 * @param tox x coordinate of the target point.
-		 * @param toy y coordinate of the target point.
-		 */
-		QuadPathElement2d(double fromx, double fromy, double ctrlx, double ctrly, double tox, double toy) {
-			super(PathElementType.QUAD_TO, tox, toy);
-			this.fromX = fromx;
-			this.fromY = fromy;
-			this.ctrlX = ctrlx;
-			this.ctrlY = ctrly;
-		}
-
-		@Pure
-		@Override
-		public boolean equals(Object obj) {
-			try {
-				final PathElement2afp elt = (PathElement2afp) obj;
-				return getType() == elt.getType()
-						&& getToX() == elt.getToX()
-						&& getToY() == elt.getToY()
-						&& getCtrlX1() == elt.getCtrlX1()
-						&& getCtrlY1() == elt.getCtrlY1()
-						&& getFromX() == elt.getFromX()
-						&& getFromY() == elt.getFromY();
-			} catch (Throwable exception) {
-				//
-			}
-			return false;
-		}
-
-		@Pure
-		@Override
-		public int hashCode() {
-			long bits = 1L;
-			bits = 31L * bits + this.type.ordinal();
-			bits = 31L * bits + Double.doubleToLongBits(getToX());
-			bits = 31L * bits + Double.doubleToLongBits(getToY());
-			bits = 31L * bits + Double.doubleToLongBits(getCtrlX1());
-			bits = 31L * bits + Double.doubleToLongBits(getCtrlY1());
-			bits = 31L * bits + Double.doubleToLongBits(getFromX());
-			bits = 31L * bits + Double.doubleToLongBits(getFromY());
-			return (int) (bits ^ (bits >> 32));
-		}
-
-		@Pure
-		@Override
-		public boolean isEmpty() {
-			if (this.isEmpty == null) {
-				this.isEmpty = MathUtil.isEpsilonEqual(this.fromX, this.toX)
-						&& MathUtil.isEpsilonEqual(this.fromY, this.toY)
-						&& MathUtil.isEpsilonEqual(this.ctrlX, this.toX)
-						&& MathUtil.isEpsilonEqual(this.ctrlY, this.toY);
-			}
-			return this.isEmpty.booleanValue();
-		}
-
-		@Pure
-		@Override
-		public boolean isDrawable() {
-			return !isEmpty();
-		}
-
-		@Override
-		public void toArray(int[] array) {
-			assert array != null : "Array must be not null"; //$NON-NLS-1$
-			assert array.length >= 4 : ARRAY_SIZE_SMALL; //$NON-NLS-1$
-			array[0] = (int) this.ctrlX;
-			array[1] = (int) this.ctrlY;
-			array[2] = (int) this.toX;
-			array[3] = (int) this.toY;
-		}
-
-		@Override
-		public void toArray(double[] array) {
-			assert array != null : "Array must be not null"; //$NON-NLS-1$
-			assert array.length >= 4 : ARRAY_SIZE_SMALL; //$NON-NLS-1$
-			array[0] = this.ctrlX;
-			array[1] = this.ctrlY;
-			array[2] = this.toX;
-			array[3] = this.toY;
-		}
-
-		@Pure
-		@Override
-		public double[] toArray() {
-			return new double[] {this.ctrlX, this.ctrlY, this.toX, this.toY};
-		}
-
-		@Pure
-		@Override
-		public String toString() {
-			return "QUAD(" //$NON-NLS-1$
-					+ this.ctrlX + "x" //$NON-NLS-1$
-					+ this.ctrlY + "|" //$NON-NLS-1$
-					+ this.toX + "x" //$NON-NLS-1$
-					+ this.toY + ")"; //$NON-NLS-1$
-		}
-
-		@Override
-		public double getFromX() {
-			return this.fromX;
-		}
-
-		@Override
-		public double getFromY() {
-			return this.fromY;
-		}
-
-		@Override
-		public double getCtrlX1() {
-			return this.ctrlX;
-		}
-
-		@Override
-		public double getCtrlY1() {
-			return this.ctrlY;
-		}
-
-	}
-
-	/** An element of the path that represents a <code>CURVE_TO</code>.
-	 *
-	 * @author $Author: sgalland$
-	 * @version $FullVersion$
-	 * @mavengroupid $GroupId$
-	 * @mavenartifactid $ArtifactId$
-	 * @since 13.0
-	 */
-	@SuppressWarnings("checkstyle:magicnumber")
-	static class CurvePathElement2d extends PathElement2d {
-
-		private static final long serialVersionUID = -2831895270995173092L;
-
-		private final double fromX;
-
-		private final double fromY;
-
-		private final double ctrlX1;
-
-		private final double ctrlY1;
-
-		private final double ctrlX2;
-
-		private final double ctrlY2;
-
-		private Boolean isEmpty;
-
-		/**
-		 * @param fromx x coordinate of the origin point.
-		 * @param fromy y coordinate of the origin point.
-		 * @param ctrlx1 x coordinate of the first control point.
-		 * @param ctrly1 y coordinate of the first control point.
-		 * @param ctrlx2 x coordinate of the second control point.
-		 * @param ctrly2 y coordinate of the second control point.
-		 * @param tox x coordinate of the target point.
-		 * @param toy y coordinate of the target point.
-		 */
-		CurvePathElement2d(double fromx, double fromy, double ctrlx1, double ctrly1, double ctrlx2,
-				double ctrly2, double tox, double toy) {
-			super(PathElementType.CURVE_TO, tox, toy);
-			this.fromX = fromx;
-			this.fromY = fromy;
-			this.ctrlX1 = ctrlx1;
-			this.ctrlY1 = ctrly1;
-			this.ctrlX2 = ctrlx2;
-			this.ctrlY2 = ctrly2;
-		}
-
-		@Pure
-		@Override
-		public boolean equals(Object obj) {
-			try {
-				final PathElement2afp elt = (PathElement2afp) obj;
-				return getType() == elt.getType()
-						&& getToX() == elt.getToX()
-						&& getToY() == elt.getToY()
-						&& getCtrlX1() == elt.getCtrlX1()
-						&& getCtrlY1() == elt.getCtrlY1()
-						&& getCtrlX2() == elt.getCtrlX2()
-						&& getCtrlY2() == elt.getCtrlY2()
-						&& getFromX() == elt.getFromX()
-						&& getFromY() == elt.getFromY();
-			} catch (Throwable exception) {
-				//
-			}
-			return false;
-		}
-
-		@Pure
-		@Override
-		public int hashCode() {
-			long bits = 1L;
-			bits = 31L * bits + this.type.ordinal();
-			bits = 31L * bits + Double.doubleToLongBits(getToX());
-			bits = 31L * bits + Double.doubleToLongBits(getToY());
-			bits = 31L * bits + Double.doubleToLongBits(getCtrlX1());
-			bits = 31L * bits + Double.doubleToLongBits(getCtrlY1());
-			bits = 31L * bits + Double.doubleToLongBits(getCtrlX2());
-			bits = 31L * bits + Double.doubleToLongBits(getCtrlY2());
-			bits = 31L * bits + Double.doubleToLongBits(getFromX());
-			bits = 31L * bits + Double.doubleToLongBits(getFromY());
-			return (int) (bits ^ (bits >> 32));
-		}
-
-		@Pure
-		@Override
-		public boolean isEmpty() {
-			if (this.isEmpty == null) {
-				this.isEmpty = MathUtil.isEpsilonEqual(this.fromX, this.toX)
-						&& MathUtil.isEpsilonEqual(this.fromY, this.toY)
-						&& MathUtil.isEpsilonEqual(this.ctrlX1, this.toX)
-						&& MathUtil.isEpsilonEqual(this.ctrlY1, this.toY)
-						&& MathUtil.isEpsilonEqual(this.ctrlX2, this.toX)
-						&& MathUtil.isEpsilonEqual(this.ctrlY2, this.toY);
-			}
-			return this.isEmpty.booleanValue();
-		}
-
-		@Pure
-		@Override
-		public boolean isDrawable() {
-			return !isEmpty();
-		}
-
-		@Override
-		public void toArray(int[] array) {
-			assert array != null : "Array must be not null"; //$NON-NLS-1$
-			assert array.length >= 6 : ARRAY_SIZE_SMALL; //$NON-NLS-1$
-			array[0] = (int) this.ctrlX1;
-			array[1] = (int) this.ctrlY1;
-			array[2] = (int) this.ctrlX2;
-			array[3] = (int) this.ctrlY2;
-			array[4] = (int) this.toX;
-			array[5] = (int) this.toY;
-		}
-
-		@Override
-		public void toArray(double[] array) {
-			assert array != null : "Array must be not null"; //$NON-NLS-1$
-			assert array.length >= 6 : ARRAY_SIZE_SMALL; //$NON-NLS-1$
-			array[0] = this.ctrlX1;
-			array[1] = this.ctrlY1;
-			array[2] = this.ctrlX2;
-			array[3] = this.ctrlY2;
-			array[4] = this.toX;
-			array[5] = this.toY;
-		}
-
-		@Pure
-		@Override
-		public double[] toArray() {
-			return new double[] {this.ctrlX1, this.ctrlY1, this.ctrlX2, this.ctrlY2, this.toX, this.toY};
-		}
-
-		@Pure
-		@Override
-		public String toString() {
-			return "CURVE(" //$NON-NLS-1$
-					+ this.ctrlX1 + "x" //$NON-NLS-1$
-					+ this.ctrlY1 + "|" //$NON-NLS-1$
-					+ this.ctrlX2 + "x" //$NON-NLS-1$
-					+ this.ctrlY2 + "|" //$NON-NLS-1$
-					+ this.toX + "x" //$NON-NLS-1$
-					+ this.toY + ")"; //$NON-NLS-1$
-		}
-
-		@Override
-		public double getFromX() {
-			return this.fromX;
-		}
-
-		@Override
-		public double getFromY() {
-			return this.fromY;
-		}
-
-		@Override
-		public double getCtrlX1() {
-			return this.ctrlX1;
-		}
-
-		@Override
-		public double getCtrlY1() {
-			return this.ctrlY1;
-		}
-
-		@Override
-		public double getCtrlX2() {
-			return this.ctrlX2;
-		}
-
-		@Override
-		public double getCtrlY2() {
-			return this.ctrlY2;
-		}
-
-	}
-
-	/** An element of the path that represents a <code>CLOSE</code>.
-	 *
-	 * @author $Author: sgalland$
-	 * @version $FullVersion$
-	 * @mavengroupid $GroupId$
-	 * @mavenartifactid $ArtifactId$
-	 * @since 13.0
-	 */
-	static class ClosePathElement2d extends PathElement2d {
-
-		private static final long serialVersionUID = 5324688417590599323L;
-
-		private final double fromX;
-
-		private final double fromY;
-
-		private Boolean isEmpty;
-
-		/**
-		 * @param fromx x coordinate of the origin point.
-		 * @param fromy y coordinate of the origin point.
-		 * @param tox x coordinate of the target point.
-		 * @param toy y coordinate of the target point.
-		 */
-		ClosePathElement2d(double fromx, double fromy, double tox, double toy) {
-			super(PathElementType.CLOSE, tox, toy);
-			this.fromX = fromx;
-			this.fromY = fromy;
-		}
-
-		@Pure
-		@Override
-		public boolean equals(Object obj) {
-			try {
-				final PathElement2afp elt = (PathElement2afp) obj;
-				return getType() == elt.getType()
-						&& getToX() == elt.getToX()
-						&& getToY() == elt.getToY()
-						&& getFromX() == elt.getFromX()
-						&& getFromY() == elt.getFromY();
-			} catch (Throwable exception) {
-				//
-			}
-			return false;
-		}
-
-		@Pure
-		@Override
-		public int hashCode() {
-			long bits = 1L;
-			bits = 31L * bits + this.type.ordinal();
-			bits = 31L * bits + Double.doubleToLongBits(getToX());
-			bits = 31L * bits + Double.doubleToLongBits(getToY());
-			bits = 31L * bits + Double.doubleToLongBits(getFromX());
-			bits = 31L * bits + Double.doubleToLongBits(getFromY());
-			return (int) (bits ^ (bits >> 32));
-		}
-
-		@Pure
-		@Override
-		public boolean isEmpty() {
-			if (this.isEmpty == null) {
-				this.isEmpty = MathUtil.isEpsilonEqual(this.fromX, this.toX)
-						&& MathUtil.isEpsilonEqual(this.fromY, this.toY);
-			}
-			return this.isEmpty.booleanValue();
-		}
-
-		@Pure
-		@Override
-		public boolean isDrawable() {
-			return !isEmpty();
-		}
-
-		@Override
-		public void toArray(int[] array) {
-			assert array != null : "Array must be not null"; //$NON-NLS-1$
-			assert array.length >= 2 : ARRAY_SIZE_SMALL; //$NON-NLS-1$
-			array[0] = (int) this.toX;
-			array[1] = (int) this.toY;
-		}
-
-		@Override
-		public void toArray(double[] array) {
-			assert array != null : "Array must be not null"; //$NON-NLS-1$
-			assert array.length >= 2 : ARRAY_SIZE_SMALL; //$NON-NLS-1$
-			array[0] = this.toX;
-			array[1] = this.toY;
-		}
-
-		@Pure
-		@Override
-		public double[] toArray() {
-			return new double[] {this.toX, this.toY};
-		}
-
-		@Pure
-		@Override
-		public String toString() {
-			return "CLOSE"; //$NON-NLS-1$
-		}
-
-		@Override
-		public double getFromX() {
-			return this.fromX;
-		}
-
-		@Override
-		public double getFromY() {
-			return this.fromY;
-		}
-
-	}
-
-	/** An element of the path that represents a <code>Arc_TO</code>.
-	 *
-	 * @author $Author: sgalland$
-	 * @version $FullVersion$
-	 * @mavengroupid $GroupId$
-	 * @mavenartifactid $ArtifactId$
-	 * @since 13.0
-	 */
-	@SuppressWarnings("checkstyle:magicnumber")
-	static class ArcPathElement2d extends PathElement2d {
-
-		private static final long serialVersionUID = -2831895270995173092L;
-
-		private final double fromX;
-
-		private final double fromY;
-
-		private final double xradius;
-
-		private final double yradius;
-
-		private final double xrotation;
-
-		private final boolean largeArcFlag;
-
-		private boolean sweepFlag;
-
-		private Boolean isEmpty;
-
-		/**
-		 * @param fromx x coordinate of the origin point.
-		 * @param fromy y coordinate of the origin point.
-		 * @param tox x coordinate of the target point.
-		 * @param toy y coordinate of the target point.
-		 * @param xradius radius of the ellipse along its x axis.
-		 * @param yradius radius of the ellipse along its y axis.
-		 * @param xrotation rotation (in radians) of the ellipse's x axis.
-		 * @param largeArcFlag <code>true</code> iff the path will sweep the long way around the ellipse.
-		 * @param sweepFlag <code>true</code> iff the path will sweep clockwise around the ellipse.
-		 */
-		ArcPathElement2d(double fromx, double fromy, double tox, double toy, double xradius,
-				double yradius, double xrotation, boolean largeArcFlag, boolean sweepFlag) {
-			super(PathElementType.ARC_TO, tox, toy);
-			this.fromX = fromx;
-			this.fromY = fromy;
-			this.xradius = xradius;
-			this.yradius = yradius;
-			this.xrotation = xrotation;
-			this.largeArcFlag = largeArcFlag;
-			this.sweepFlag = sweepFlag;
-		}
-
-		@Pure
-		@Override
-		public boolean equals(Object obj) {
-			try {
-				final PathElement2afp elt = (PathElement2afp) obj;
-				return getType() == elt.getType()
-						&& getToX() == elt.getToX()
-						&& getToY() == elt.getToY()
-						&& getRadiusX() == elt.getRadiusX()
-						&& getRadiusY() == elt.getRadiusY()
-						&& getRotationX() == elt.getRotationX()
-						&& getLargeArcFlag() == elt.getLargeArcFlag()
-						&& getSweepFlag() == elt.getSweepFlag();
-			} catch (Throwable exception) {
-				//
-			}
-			return false;
-		}
-
-		@Pure
-		@Override
-		public int hashCode() {
-			long bits = 1L;
-			bits = 31L * bits + this.type.ordinal();
-			bits = 31L * bits + Double.doubleToLongBits(getToX());
-			bits = 31L * bits + Double.doubleToLongBits(getToY());
-			bits = 31L * bits + Double.doubleToLongBits(getRadiusX());
-			bits = 31L * bits + Double.doubleToLongBits(getRadiusY());
-			bits = 31L * bits + Double.doubleToLongBits(getRotationX());
-			bits = 31L * bits + Boolean.hashCode(getLargeArcFlag());
-			bits = 31L * bits + Boolean.hashCode(getSweepFlag());
-			return (int) (bits ^ (bits >> 32));
-		}
-
-		@Pure
-		@Override
-		public boolean isEmpty() {
-			if (this.isEmpty == null) {
-				this.isEmpty = MathUtil.isEpsilonEqual(this.fromX, this.toX)
-						&& MathUtil.isEpsilonEqual(this.fromY, this.toY);
-			}
-			return this.isEmpty.booleanValue();
-		}
-
-		@Pure
-		@Override
-		public boolean isDrawable() {
-			return !isEmpty();
-		}
-
-		@Override
-		public void toArray(int[] array) {
-			assert array != null : "Array must be not null"; //$NON-NLS-1$
-			assert array.length >= 2 : ARRAY_SIZE_SMALL; //$NON-NLS-1$
-			array[0] = (int) this.toX;
-			array[1] = (int) this.toY;
-		}
-
-		@Override
-		public void toArray(double[] array) {
-			assert array != null : "Array must be not null"; //$NON-NLS-1$
-			assert array.length >= 2 : ARRAY_SIZE_SMALL; //$NON-NLS-1$
-			array[0] = this.toX;
-			array[1] = this.toY;
-		}
-
-		@Pure
-		@Override
-		public double[] toArray() {
-			return new double[] {this.toX, this.toY};
-		}
-
-		@Pure
-		@Override
-		public String toString() {
-			return "ARC(" //$NON-NLS-1$
-					+ getRadiusX() + "x" //$NON-NLS-1$
-					+ getRadiusY() + "|" //$NON-NLS-1$
-					+ getRotationX() + "x" //$NON-NLS-1$
-					+ getLargeArcFlag() + "x" //$NON-NLS-1$
-					+ getSweepFlag() + "|" //$NON-NLS-1$
-					+ getToX() + "x" //$NON-NLS-1$
-					+ getToY() + ")"; //$NON-NLS-1$
-		}
-
-		@Override
-		public double getFromX() {
-			return this.fromX;
-		}
-
-		@Override
-		public double getFromY() {
-			return this.fromY;
-		}
-
-		@Override
-		public double getRadiusX() {
-			return this.xradius;
-		}
-
-		@Override
-		public double getRadiusY() {
-			return this.yradius;
-		}
-
-		@Override
-		public double getRotationX() {
-			return this.xrotation;
-		}
-
-		@Override
-		public boolean getSweepFlag() {
-			return this.sweepFlag;
-		}
-
-		@Override
-		public boolean getLargeArcFlag() {
-			return this.largeArcFlag;
-		}
-
-	}
+    /** Type of the element.
+     */
+    protected final PathElementType type;
+
+    /** Target point.
+     */
+    protected final double toX;
+
+    /** Target point.
+     */
+    protected final double toY;
+
+    /**
+     * @param type is the type of the element.
+     * @param tox the x coordinate of the target point.
+     * @param toy the x coordinate of the target point.
+     */
+    PathElement2d(PathElementType type, double tox, double toy) {
+        assert type != null : "Path element type must be not null"; //$NON-NLS-1$
+        this.type = type;
+        this.toX = tox;
+        this.toY = toy;
+    }
+
+    @Pure
+    @Override
+    public abstract boolean equals(Object obj);
+
+    @Pure
+    @Override
+    public abstract int hashCode();
+
+    @Override
+    @Pure
+    public final double getToX() {
+        return this.toX;
+    }
+
+    @Override
+    @Pure
+    public final double getToY() {
+        return this.toY;
+    }
+
+    @Pure
+    @Override
+    public final PathElementType getType() {
+        return this.type;
+    }
+
+    @Override
+    public double getCtrlX1() {
+        return 0;
+    }
+
+    @Override
+    public double getCtrlY1() {
+        return 0;
+    }
+
+    @Override
+    public double getCtrlX2() {
+        return 0;
+    }
+
+    @Override
+    public double getCtrlY2() {
+        return 0;
+    }
+
+    @Override
+    public double getRadiusX() {
+        return 0;
+    }
+
+    @Override
+    public double getRadiusY() {
+        return 0;
+    }
+
+    @Override
+    public double getRotationX() {
+        return 0;
+    }
+
+    @Override
+    public boolean getSweepFlag() {
+        return false;
+    }
+
+    @Override
+    public boolean getLargeArcFlag() {
+        return false;
+    }
+
+    /** Copy the coords into an array, except the source point.
+     *
+     * @return the array of the points, except the source point.
+     */
+    @Pure
+    public abstract double[] toArray();
+
+    /** An element of the path that represents a <code>MOVE_TO</code>.
+     *
+     * @author $Author: sgalland$
+     * @version $FullVersion$
+     * @mavengroupid $GroupId$
+     * @mavenartifactid $ArtifactId$
+     * @since 13.0
+     */
+    static class MovePathElement2d extends PathElement2d {
+
+        private static final long serialVersionUID = -399575136145167775L;
+
+        /**
+         * @param tox x coordinate of the target point.
+         * @param toy y coordinate of the target point.
+         */
+        MovePathElement2d(double tox, double toy) {
+            super(PathElementType.MOVE_TO, tox, toy);
+        }
+
+        @Pure
+        @Override
+        public boolean equals(Object obj) {
+            try {
+                final PathElement2afp elt = (PathElement2afp) obj;
+                return getType() == elt.getType()
+                        && getToX() == elt.getToX()
+                        && getToY() == elt.getToY();
+            } catch (Throwable exception) {
+                //
+            }
+            return false;
+        }
+
+        @Pure
+        @Override
+        public int hashCode() {
+            long bits = 1L;
+            bits = 31L * bits + this.type.ordinal();
+            bits = 31L * bits + Double.doubleToLongBits(getToX());
+            bits = 31L * bits + Double.doubleToLongBits(getToY());
+            return (int) (bits ^ (bits >> 32));
+        }
+
+        @Pure
+        @Override
+        public boolean isEmpty() {
+            return true;
+        }
+
+        @Pure
+        @Override
+        public boolean isDrawable() {
+            return false;
+        }
+
+        @Override
+        public void toArray(int[] array) {
+            assert array != null : "Array must be not null"; //$NON-NLS-1$
+            assert array.length >= 2 : ARRAY_SIZE_SMALL; //$NON-NLS-1$
+            array[0] = (int) this.toX;
+            array[1] = (int) this.toY;
+        }
+
+        @Override
+        public void toArray(double[] array) {
+            assert array != null : "Array must be not null"; //$NON-NLS-1$
+            assert array.length >= 2 : ARRAY_SIZE_SMALL; //$NON-NLS-1$
+            array[0] = this.toX;
+            array[1] = this.toY;
+        }
+
+        @Pure
+        @Override
+        public double[] toArray() {
+            return new double[] {this.toX, this.toY};
+        }
+
+        @Pure
+        @Override
+        public String toString() {
+            return "MOVE(" //$NON-NLS-1$
+                    + this.toX + "x" //$NON-NLS-1$
+                    + this.toY + ")"; //$NON-NLS-1$
+        }
+
+        @Override
+        public double getFromX() {
+            return 0.;
+        }
+
+        @Override
+        public double getFromY() {
+            return 0.;
+        }
+
+    }
+
+    /** An element of the path that represents a <code>LINE_TO</code>.
+     *
+     * @author $Author: sgalland$
+     * @version $FullVersion$
+     * @mavengroupid $GroupId$
+     * @mavenartifactid $ArtifactId$
+     * @since 13.0
+     */
+    static class LinePathElement2d extends PathElement2d {
+
+        private static final long serialVersionUID = 8423845888008307447L;
+
+        private final double fromX;
+
+        private final double fromY;
+
+        private Boolean isEmpty;
+
+        /**
+         * @param fromx x coordinate of the origin point.
+         * @param fromy y coordinate of the origin point.
+         * @param tox x coordinate of the target point.
+         * @param toy y coordinate of the target point.
+         */
+        LinePathElement2d(double fromx, double fromy, double tox, double toy) {
+            super(PathElementType.LINE_TO, tox, toy);
+            this.fromX = fromx;
+            this.fromY = fromy;
+        }
+
+        @Pure
+        @Override
+        public boolean equals(Object obj) {
+            try {
+                final PathElement2afp elt = (PathElement2afp) obj;
+                return getType() == elt.getType()
+                        && getToX() == elt.getToX()
+                        && getToY() == elt.getToY()
+                        && getFromX() == elt.getFromX()
+                        && getFromY() == elt.getFromY();
+            } catch (Throwable exception) {
+                //
+            }
+            return false;
+        }
+
+        @Pure
+        @Override
+        public int hashCode() {
+            long bits = 1L;
+            bits = 31L * bits + this.type.ordinal();
+            bits = 31L * bits + Double.doubleToLongBits(getToX());
+            bits = 31L * bits + Double.doubleToLongBits(getToY());
+            bits = 31L * bits + Double.doubleToLongBits(getFromX());
+            bits = 31L * bits + Double.doubleToLongBits(getFromY());
+            return (int) (bits ^ (bits >> 32));
+        }
+
+        @Pure
+        @Override
+        public boolean isEmpty() {
+            if (this.isEmpty == null) {
+                this.isEmpty = MathUtil.isEpsilonEqual(this.fromX, this.toX)
+                        && MathUtil.isEpsilonEqual(this.fromY, this.toY);
+            }
+            return this.isEmpty.booleanValue();
+        }
+
+        @Pure
+        @Override
+        public boolean isDrawable() {
+            return !isEmpty();
+        }
+
+        @Override
+        public void toArray(int[] array) {
+            assert array != null : "Array must be not null"; //$NON-NLS-1$
+            assert array.length >= 2 : ARRAY_SIZE_SMALL; //$NON-NLS-1$
+            array[0] = (int) this.toX;
+            array[1] = (int) this.toY;
+        }
+
+        @Override
+        public void toArray(double[] array) {
+            assert array != null : "Array must be not null"; //$NON-NLS-1$
+            assert array.length >= 2 : ARRAY_SIZE_SMALL; //$NON-NLS-1$
+            array[0] = this.toX;
+            array[1] = this.toY;
+        }
+
+        @Pure
+        @Override
+        public double[] toArray() {
+            return new double[] {this.toX, this.toY};
+        }
+
+        @Pure
+        @Override
+        public String toString() {
+            return "LINE(" //$NON-NLS-1$
+                    + this.toX + "x" //$NON-NLS-1$
+                    + this.toY + ")"; //$NON-NLS-1$
+        }
+
+        @Override
+        public double getFromX() {
+            return this.fromX;
+        }
+
+        @Override
+        public double getFromY() {
+            return this.fromY;
+        }
+
+    }
+
+    /** An element of the path that represents a <code>QUAD_TO</code>.
+     *
+     * @author $Author: sgalland$
+     * @version $FullVersion$
+     * @mavengroupid $GroupId$
+     * @mavenartifactid $ArtifactId$
+     * @since 13.0
+     */
+    @SuppressWarnings("checkstyle:magicnumber")
+    static class QuadPathElement2d extends PathElement2d {
+
+        private static final long serialVersionUID = 6092391345111872481L;
+
+        private final double fromX;
+
+        private final double fromY;
+
+        private final double ctrlX;
+
+        private final double ctrlY;
+
+        private Boolean isEmpty;
+
+        /**
+         * @param fromx x coordinate of the origin point.
+         * @param fromy y coordinate of the origin point.
+         * @param ctrlx x coordinate of the control point.
+         * @param ctrly y coordinate of the control point.
+         * @param tox x coordinate of the target point.
+         * @param toy y coordinate of the target point.
+         */
+        QuadPathElement2d(double fromx, double fromy, double ctrlx, double ctrly, double tox, double toy) {
+            super(PathElementType.QUAD_TO, tox, toy);
+            this.fromX = fromx;
+            this.fromY = fromy;
+            this.ctrlX = ctrlx;
+            this.ctrlY = ctrly;
+        }
+
+        @Pure
+        @Override
+        public boolean equals(Object obj) {
+            try {
+                final PathElement2afp elt = (PathElement2afp) obj;
+                return getType() == elt.getType()
+                        && getToX() == elt.getToX()
+                        && getToY() == elt.getToY()
+                        && getCtrlX1() == elt.getCtrlX1()
+                        && getCtrlY1() == elt.getCtrlY1()
+                        && getFromX() == elt.getFromX()
+                        && getFromY() == elt.getFromY();
+            } catch (Throwable exception) {
+                //
+            }
+            return false;
+        }
+
+        @Pure
+        @Override
+        public int hashCode() {
+            long bits = 1L;
+            bits = 31L * bits + this.type.ordinal();
+            bits = 31L * bits + Double.doubleToLongBits(getToX());
+            bits = 31L * bits + Double.doubleToLongBits(getToY());
+            bits = 31L * bits + Double.doubleToLongBits(getCtrlX1());
+            bits = 31L * bits + Double.doubleToLongBits(getCtrlY1());
+            bits = 31L * bits + Double.doubleToLongBits(getFromX());
+            bits = 31L * bits + Double.doubleToLongBits(getFromY());
+            return (int) (bits ^ (bits >> 32));
+        }
+
+        @Pure
+        @Override
+        public boolean isEmpty() {
+            if (this.isEmpty == null) {
+                this.isEmpty = MathUtil.isEpsilonEqual(this.fromX, this.toX)
+                        && MathUtil.isEpsilonEqual(this.fromY, this.toY)
+                        && MathUtil.isEpsilonEqual(this.ctrlX, this.toX)
+                        && MathUtil.isEpsilonEqual(this.ctrlY, this.toY);
+            }
+            return this.isEmpty.booleanValue();
+        }
+
+        @Pure
+        @Override
+        public boolean isDrawable() {
+            return !isEmpty();
+        }
+
+        @Override
+        public void toArray(int[] array) {
+            assert array != null : "Array must be not null"; //$NON-NLS-1$
+            assert array.length >= 4 : ARRAY_SIZE_SMALL; //$NON-NLS-1$
+            array[0] = (int) this.ctrlX;
+            array[1] = (int) this.ctrlY;
+            array[2] = (int) this.toX;
+            array[3] = (int) this.toY;
+        }
+
+        @Override
+        public void toArray(double[] array) {
+            assert array != null : "Array must be not null"; //$NON-NLS-1$
+            assert array.length >= 4 : ARRAY_SIZE_SMALL; //$NON-NLS-1$
+            array[0] = this.ctrlX;
+            array[1] = this.ctrlY;
+            array[2] = this.toX;
+            array[3] = this.toY;
+        }
+
+        @Pure
+        @Override
+        public double[] toArray() {
+            return new double[] {this.ctrlX, this.ctrlY, this.toX, this.toY};
+        }
+
+        @Pure
+        @Override
+        public String toString() {
+            return "QUAD(" //$NON-NLS-1$
+                    + this.ctrlX + "x" //$NON-NLS-1$
+                    + this.ctrlY + "|" //$NON-NLS-1$
+                    + this.toX + "x" //$NON-NLS-1$
+                    + this.toY + ")"; //$NON-NLS-1$
+        }
+
+        @Override
+        public double getFromX() {
+            return this.fromX;
+        }
+
+        @Override
+        public double getFromY() {
+            return this.fromY;
+        }
+
+        @Override
+        public double getCtrlX1() {
+            return this.ctrlX;
+        }
+
+        @Override
+        public double getCtrlY1() {
+            return this.ctrlY;
+        }
+
+    }
+
+    /** An element of the path that represents a <code>CURVE_TO</code>.
+     *
+     * @author $Author: sgalland$
+     * @version $FullVersion$
+     * @mavengroupid $GroupId$
+     * @mavenartifactid $ArtifactId$
+     * @since 13.0
+     */
+    @SuppressWarnings("checkstyle:magicnumber")
+    static class CurvePathElement2d extends PathElement2d {
+
+        private static final long serialVersionUID = -2831895270995173092L;
+
+        private final double fromX;
+
+        private final double fromY;
+
+        private final double ctrlX1;
+
+        private final double ctrlY1;
+
+        private final double ctrlX2;
+
+        private final double ctrlY2;
+
+        private Boolean isEmpty;
+
+        /**
+         * @param fromx x coordinate of the origin point.
+         * @param fromy y coordinate of the origin point.
+         * @param ctrlx1 x coordinate of the first control point.
+         * @param ctrly1 y coordinate of the first control point.
+         * @param ctrlx2 x coordinate of the second control point.
+         * @param ctrly2 y coordinate of the second control point.
+         * @param tox x coordinate of the target point.
+         * @param toy y coordinate of the target point.
+         */
+        CurvePathElement2d(double fromx, double fromy, double ctrlx1, double ctrly1, double ctrlx2,
+                double ctrly2, double tox, double toy) {
+            super(PathElementType.CURVE_TO, tox, toy);
+            this.fromX = fromx;
+            this.fromY = fromy;
+            this.ctrlX1 = ctrlx1;
+            this.ctrlY1 = ctrly1;
+            this.ctrlX2 = ctrlx2;
+            this.ctrlY2 = ctrly2;
+        }
+
+        @Pure
+        @Override
+        public boolean equals(Object obj) {
+            try {
+                final PathElement2afp elt = (PathElement2afp) obj;
+                return getType() == elt.getType()
+                        && getToX() == elt.getToX()
+                        && getToY() == elt.getToY()
+                        && getCtrlX1() == elt.getCtrlX1()
+                        && getCtrlY1() == elt.getCtrlY1()
+                        && getCtrlX2() == elt.getCtrlX2()
+                        && getCtrlY2() == elt.getCtrlY2()
+                        && getFromX() == elt.getFromX()
+                        && getFromY() == elt.getFromY();
+            } catch (Throwable exception) {
+                //
+            }
+            return false;
+        }
+
+        @Pure
+        @Override
+        public int hashCode() {
+            long bits = 1L;
+            bits = 31L * bits + this.type.ordinal();
+            bits = 31L * bits + Double.doubleToLongBits(getToX());
+            bits = 31L * bits + Double.doubleToLongBits(getToY());
+            bits = 31L * bits + Double.doubleToLongBits(getCtrlX1());
+            bits = 31L * bits + Double.doubleToLongBits(getCtrlY1());
+            bits = 31L * bits + Double.doubleToLongBits(getCtrlX2());
+            bits = 31L * bits + Double.doubleToLongBits(getCtrlY2());
+            bits = 31L * bits + Double.doubleToLongBits(getFromX());
+            bits = 31L * bits + Double.doubleToLongBits(getFromY());
+            return (int) (bits ^ (bits >> 32));
+        }
+
+        @Pure
+        @Override
+        public boolean isEmpty() {
+            if (this.isEmpty == null) {
+                this.isEmpty = MathUtil.isEpsilonEqual(this.fromX, this.toX)
+                        && MathUtil.isEpsilonEqual(this.fromY, this.toY)
+                        && MathUtil.isEpsilonEqual(this.ctrlX1, this.toX)
+                        && MathUtil.isEpsilonEqual(this.ctrlY1, this.toY)
+                        && MathUtil.isEpsilonEqual(this.ctrlX2, this.toX)
+                        && MathUtil.isEpsilonEqual(this.ctrlY2, this.toY);
+            }
+            return this.isEmpty.booleanValue();
+        }
+
+        @Pure
+        @Override
+        public boolean isDrawable() {
+            return !isEmpty();
+        }
+
+        @Override
+        public void toArray(int[] array) {
+            assert array != null : "Array must be not null"; //$NON-NLS-1$
+            assert array.length >= 6 : ARRAY_SIZE_SMALL; //$NON-NLS-1$
+            array[0] = (int) this.ctrlX1;
+            array[1] = (int) this.ctrlY1;
+            array[2] = (int) this.ctrlX2;
+            array[3] = (int) this.ctrlY2;
+            array[4] = (int) this.toX;
+            array[5] = (int) this.toY;
+        }
+
+        @Override
+        public void toArray(double[] array) {
+            assert array != null : "Array must be not null"; //$NON-NLS-1$
+            assert array.length >= 6 : ARRAY_SIZE_SMALL; //$NON-NLS-1$
+            array[0] = this.ctrlX1;
+            array[1] = this.ctrlY1;
+            array[2] = this.ctrlX2;
+            array[3] = this.ctrlY2;
+            array[4] = this.toX;
+            array[5] = this.toY;
+        }
+
+        @Pure
+        @Override
+        public double[] toArray() {
+            return new double[] {this.ctrlX1, this.ctrlY1, this.ctrlX2, this.ctrlY2, this.toX, this.toY};
+        }
+
+        @Pure
+        @Override
+        public String toString() {
+            return "CURVE(" //$NON-NLS-1$
+                    + this.ctrlX1 + "x" //$NON-NLS-1$
+                    + this.ctrlY1 + "|" //$NON-NLS-1$
+                    + this.ctrlX2 + "x" //$NON-NLS-1$
+                    + this.ctrlY2 + "|" //$NON-NLS-1$
+                    + this.toX + "x" //$NON-NLS-1$
+                    + this.toY + ")"; //$NON-NLS-1$
+        }
+
+        @Override
+        public double getFromX() {
+            return this.fromX;
+        }
+
+        @Override
+        public double getFromY() {
+            return this.fromY;
+        }
+
+        @Override
+        public double getCtrlX1() {
+            return this.ctrlX1;
+        }
+
+        @Override
+        public double getCtrlY1() {
+            return this.ctrlY1;
+        }
+
+        @Override
+        public double getCtrlX2() {
+            return this.ctrlX2;
+        }
+
+        @Override
+        public double getCtrlY2() {
+            return this.ctrlY2;
+        }
+
+    }
+
+    /** An element of the path that represents a <code>CLOSE</code>.
+     *
+     * @author $Author: sgalland$
+     * @version $FullVersion$
+     * @mavengroupid $GroupId$
+     * @mavenartifactid $ArtifactId$
+     * @since 13.0
+     */
+    static class ClosePathElement2d extends PathElement2d {
+
+        private static final long serialVersionUID = 5324688417590599323L;
+
+        private final double fromX;
+
+        private final double fromY;
+
+        private Boolean isEmpty;
+
+        /**
+         * @param fromx x coordinate of the origin point.
+         * @param fromy y coordinate of the origin point.
+         * @param tox x coordinate of the target point.
+         * @param toy y coordinate of the target point.
+         */
+        ClosePathElement2d(double fromx, double fromy, double tox, double toy) {
+            super(PathElementType.CLOSE, tox, toy);
+            this.fromX = fromx;
+            this.fromY = fromy;
+        }
+
+        @Pure
+        @Override
+        public boolean equals(Object obj) {
+            try {
+                final PathElement2afp elt = (PathElement2afp) obj;
+                return getType() == elt.getType()
+                        && getToX() == elt.getToX()
+                        && getToY() == elt.getToY()
+                        && getFromX() == elt.getFromX()
+                        && getFromY() == elt.getFromY();
+            } catch (Throwable exception) {
+                //
+            }
+            return false;
+        }
+
+        @Pure
+        @Override
+        public int hashCode() {
+            long bits = 1L;
+            bits = 31L * bits + this.type.ordinal();
+            bits = 31L * bits + Double.doubleToLongBits(getToX());
+            bits = 31L * bits + Double.doubleToLongBits(getToY());
+            bits = 31L * bits + Double.doubleToLongBits(getFromX());
+            bits = 31L * bits + Double.doubleToLongBits(getFromY());
+            return (int) (bits ^ (bits >> 32));
+        }
+
+        @Pure
+        @Override
+        public boolean isEmpty() {
+            if (this.isEmpty == null) {
+                this.isEmpty = MathUtil.isEpsilonEqual(this.fromX, this.toX)
+                        && MathUtil.isEpsilonEqual(this.fromY, this.toY);
+            }
+            return this.isEmpty.booleanValue();
+        }
+
+        @Pure
+        @Override
+        public boolean isDrawable() {
+            return !isEmpty();
+        }
+
+        @Override
+        public void toArray(int[] array) {
+            assert array != null : "Array must be not null"; //$NON-NLS-1$
+            assert array.length >= 2 : ARRAY_SIZE_SMALL; //$NON-NLS-1$
+            array[0] = (int) this.toX;
+            array[1] = (int) this.toY;
+        }
+
+        @Override
+        public void toArray(double[] array) {
+            assert array != null : "Array must be not null"; //$NON-NLS-1$
+            assert array.length >= 2 : ARRAY_SIZE_SMALL; //$NON-NLS-1$
+            array[0] = this.toX;
+            array[1] = this.toY;
+        }
+
+        @Pure
+        @Override
+        public double[] toArray() {
+            return new double[] {this.toX, this.toY};
+        }
+
+        @Pure
+        @Override
+        public String toString() {
+            return "CLOSE"; //$NON-NLS-1$
+        }
+
+        @Override
+        public double getFromX() {
+            return this.fromX;
+        }
+
+        @Override
+        public double getFromY() {
+            return this.fromY;
+        }
+
+    }
+
+    /** An element of the path that represents a <code>Arc_TO</code>.
+     *
+     * @author $Author: sgalland$
+     * @version $FullVersion$
+     * @mavengroupid $GroupId$
+     * @mavenartifactid $ArtifactId$
+     * @since 13.0
+     */
+    @SuppressWarnings("checkstyle:magicnumber")
+    static class ArcPathElement2d extends PathElement2d {
+
+        private static final long serialVersionUID = -2831895270995173092L;
+
+        private final double fromX;
+
+        private final double fromY;
+
+        private final double xradius;
+
+        private final double yradius;
+
+        private final double xrotation;
+
+        private final boolean largeArcFlag;
+
+        private boolean sweepFlag;
+
+        private Boolean isEmpty;
+
+        /**
+         * @param fromx x coordinate of the origin point.
+         * @param fromy y coordinate of the origin point.
+         * @param tox x coordinate of the target point.
+         * @param toy y coordinate of the target point.
+         * @param xradius radius of the ellipse along its x axis.
+         * @param yradius radius of the ellipse along its y axis.
+         * @param xrotation rotation (in radians) of the ellipse's x axis.
+         * @param largeArcFlag <code>true</code> iff the path will sweep the long way around the ellipse.
+         * @param sweepFlag <code>true</code> iff the path will sweep clockwise around the ellipse.
+         */
+        ArcPathElement2d(double fromx, double fromy, double tox, double toy, double xradius,
+                double yradius, double xrotation, boolean largeArcFlag, boolean sweepFlag) {
+            super(PathElementType.ARC_TO, tox, toy);
+            this.fromX = fromx;
+            this.fromY = fromy;
+            this.xradius = xradius;
+            this.yradius = yradius;
+            this.xrotation = xrotation;
+            this.largeArcFlag = largeArcFlag;
+            this.sweepFlag = sweepFlag;
+        }
+
+        @Pure
+        @Override
+        public boolean equals(Object obj) {
+            try {
+                final PathElement2afp elt = (PathElement2afp) obj;
+                return getType() == elt.getType()
+                        && getToX() == elt.getToX()
+                        && getToY() == elt.getToY()
+                        && getRadiusX() == elt.getRadiusX()
+                        && getRadiusY() == elt.getRadiusY()
+                        && getRotationX() == elt.getRotationX()
+                        && getLargeArcFlag() == elt.getLargeArcFlag()
+                        && getSweepFlag() == elt.getSweepFlag();
+            } catch (Throwable exception) {
+                //
+            }
+            return false;
+        }
+
+        @Pure
+        @Override
+        public int hashCode() {
+            long bits = 1L;
+            bits = 31L * bits + this.type.ordinal();
+            bits = 31L * bits + Double.doubleToLongBits(getToX());
+            bits = 31L * bits + Double.doubleToLongBits(getToY());
+            bits = 31L * bits + Double.doubleToLongBits(getRadiusX());
+            bits = 31L * bits + Double.doubleToLongBits(getRadiusY());
+            bits = 31L * bits + Double.doubleToLongBits(getRotationX());
+            bits = 31L * bits + Boolean.hashCode(getLargeArcFlag());
+            bits = 31L * bits + Boolean.hashCode(getSweepFlag());
+            return (int) (bits ^ (bits >> 32));
+        }
+
+        @Pure
+        @Override
+        public boolean isEmpty() {
+            if (this.isEmpty == null) {
+                this.isEmpty = MathUtil.isEpsilonEqual(this.fromX, this.toX)
+                        && MathUtil.isEpsilonEqual(this.fromY, this.toY);
+            }
+            return this.isEmpty.booleanValue();
+        }
+
+        @Pure
+        @Override
+        public boolean isDrawable() {
+            return !isEmpty();
+        }
+
+        @Override
+        public void toArray(int[] array) {
+            assert array != null : "Array must be not null"; //$NON-NLS-1$
+            assert array.length >= 2 : ARRAY_SIZE_SMALL; //$NON-NLS-1$
+            array[0] = (int) this.toX;
+            array[1] = (int) this.toY;
+        }
+
+        @Override
+        public void toArray(double[] array) {
+            assert array != null : "Array must be not null"; //$NON-NLS-1$
+            assert array.length >= 2 : ARRAY_SIZE_SMALL; //$NON-NLS-1$
+            array[0] = this.toX;
+            array[1] = this.toY;
+        }
+
+        @Pure
+        @Override
+        public double[] toArray() {
+            return new double[] {this.toX, this.toY};
+        }
+
+        @Pure
+        @Override
+        public String toString() {
+            return "ARC(" //$NON-NLS-1$
+                    + getRadiusX() + "x" //$NON-NLS-1$
+                    + getRadiusY() + "|" //$NON-NLS-1$
+                    + getRotationX() + "x" //$NON-NLS-1$
+                    + getLargeArcFlag() + "x" //$NON-NLS-1$
+                    + getSweepFlag() + "|" //$NON-NLS-1$
+                    + getToX() + "x" //$NON-NLS-1$
+                    + getToY() + ")"; //$NON-NLS-1$
+        }
+
+        @Override
+        public double getFromX() {
+            return this.fromX;
+        }
+
+        @Override
+        public double getFromY() {
+            return this.fromY;
+        }
+
+        @Override
+        public double getRadiusX() {
+            return this.xradius;
+        }
+
+        @Override
+        public double getRadiusY() {
+            return this.yradius;
+        }
+
+        @Override
+        public double getRotationX() {
+            return this.xrotation;
+        }
+
+        @Override
+        public boolean getSweepFlag() {
+            return this.sweepFlag;
+        }
+
+        @Override
+        public boolean getLargeArcFlag() {
+            return this.largeArcFlag;
+        }
+
+    }
 
 }


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1192 - “String literals should not be duplicated”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1192
 Please let me know if you have any questions.
 Fevzi Ozgul

<!---
@huboard:{"milestone_order":66.0,"order":0.0152587890625,"custom_state":""}
-->
