### PR TITLE
Fixing squid S1192 String literals should not be duplicated Fix 4

### DIFF
--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/OrientedRectangle2dfx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/OrientedRectangle2dfx.java
@@ -48,6 +48,10 @@ public class OrientedRectangle2dfx extends AbstractShape2dfx<OrientedRectangle2d
 		Point2dfx, Vector2dfx, Rectangle2dfx> {
 
 	private static final long serialVersionUID = -7570709068803272507L;
+	/**+
+	 * Literal constant.
+	 */
+    private static final String EXTENT_POSITIVE_OR_ZERO = "Extent must be positive or zero";
 
 	/**
 	 * Center of the OBR.
@@ -339,7 +343,7 @@ public class OrientedRectangle2dfx extends AbstractShape2dfx<OrientedRectangle2d
 
 	@Override
 	public void setFirstAxisExtent(double extent) {
-		assert extent >= 0 : "Extent must be positive or zero"; //$NON-NLS-1$
+		assert extent >= 0 : EXTENT_POSITIVE_OR_ZERO; //$NON-NLS-1$
 		firstAxisExtentProperty().set(extent);
 	}
 
@@ -370,7 +374,7 @@ public class OrientedRectangle2dfx extends AbstractShape2dfx<OrientedRectangle2d
 
 	@Override
 	public void setSecondAxisExtent(double extent) {
-		assert extent >= 0 : "Extent must be positive or zero"; //$NON-NLS-1$
+		assert extent >= 0 : EXTENT_POSITIVE_OR_ZERO; //$NON-NLS-1$
 		secondAxisExtentProperty().set(extent);
 	}
 
@@ -396,7 +400,7 @@ public class OrientedRectangle2dfx extends AbstractShape2dfx<OrientedRectangle2d
 	@Override
 	public void setFirstAxis(double x, double y, double extent) {
 		assert Vector2D.isUnitVector(x, y) : "Axis must be unit vector"; //$NON-NLS-1$
-		assert extent >= 0 : "Extent must be positive or zero"; //$NON-NLS-1$
+		assert extent >= 0 : EXTENT_POSITIVE_OR_ZERO; //$NON-NLS-1$
 		firstAxisProperty().set(x, y);
 		firstAxisExtentProperty().set(extent);
 	}
@@ -404,7 +408,7 @@ public class OrientedRectangle2dfx extends AbstractShape2dfx<OrientedRectangle2d
 	@Override
 	public void setSecondAxis(double x, double y, double extent) {
 		assert Vector2D.isUnitVector(x, y) : "Axis must be unit vector"; //$NON-NLS-1$
-		assert extent >= 0 : "Extent must be positive or zero"; //$NON-NLS-1$
+		assert extent >= 0 : EXTENT_POSITIVE_OR_ZERO; //$NON-NLS-1$
 		firstAxisProperty().set(y, -x);
 		secondAxisExtentProperty().set(extent);
 	}

--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/OrientedRectangle2dfx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/OrientedRectangle2dfx.java
@@ -46,25 +46,25 @@ import org.arakhne.afc.math.geometry.d2.afp.OrientedRectangle2afp;
 public class OrientedRectangle2dfx extends AbstractShape2dfx<OrientedRectangle2dfx>
 		implements OrientedRectangle2afp<Shape2dfx<?>, OrientedRectangle2dfx, PathElement2dfx,
 		Point2dfx, Vector2dfx, Rectangle2dfx> {
-
 	private static final long serialVersionUID = -7570709068803272507L;
-	/**+
-	 * Literal constant.
+	/**
+	 *Literal constant.
 	 */
-    private static final String EXTENT_POSITIVE_OR_ZERO = "Extent must be positive or zero";
+
+	private static final String EXTENT_POSITIVE_OR_ZERO = "Extent must be positive or zero";
 
 	/**
-	 * Center of the OBR.
+	 *Center of the OBR.
 	 */
 	private DoubleProperty cx;
 
 	/**
-	 * Center of the OBR.
+	 *Center of the OBR.
 	 */
 	private DoubleProperty cy;
 
 	/**
-	 * The first axis of the OBR.
+	 *The first axis of the OBR.
 	 */
 	private UnitVectorProperty raxis;
 

--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/Parallelogram2dfx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/Parallelogram2dfx.java
@@ -45,14 +45,17 @@ public class Parallelogram2dfx extends AbstractShape2dfx<Parallelogram2dfx>
 		implements Parallelogram2afp<Shape2dfx<?>, Parallelogram2dfx, PathElement2dfx, Point2dfx, Vector2dfx, Rectangle2dfx> {
 
 	private static final long serialVersionUID = -3880367245218796375L;
-    /**+
+
+	/**
      * Literal constant.
      */
 	private static final String FIRST_AXIS_UNIT_VECTOR = "First axis must be a unit vector";
-    /**+
+
+	/**
      * Literal constant.
      */
-    private static final String EXTENT_POSITIVE_OR_ZERO = "Extent must be positive or zero";
+	private static final String EXTENT_POSITIVE_OR_ZERO = "Extent must be positive or zero";
+
 	/**
 	 * Center of the parallelogram.
 	 */

--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/Parallelogram2dfx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/Parallelogram2dfx.java
@@ -45,7 +45,14 @@ public class Parallelogram2dfx extends AbstractShape2dfx<Parallelogram2dfx>
 		implements Parallelogram2afp<Shape2dfx<?>, Parallelogram2dfx, PathElement2dfx, Point2dfx, Vector2dfx, Rectangle2dfx> {
 
 	private static final long serialVersionUID = -3880367245218796375L;
-
+    /**+
+     * Literal constant.
+     */
+	private static final String FIRST_AXIS_UNIT_VECTOR = "First axis must be a unit vector";
+    /**+
+     * Literal constant.
+     */
+    private static final String EXTENT_POSITIVE_OR_ZERO = "Extent must be positive or zero";
 	/**
 	 * Center of the parallelogram.
 	 */
@@ -125,7 +132,7 @@ public class Parallelogram2dfx extends AbstractShape2dfx<Parallelogram2dfx>
 	public Parallelogram2dfx(double centerX, double centerY,
 			double axis1X, double axis1Y, double axis1Extent,
 			double axis2X, double axis2Y, double axis2Extent) {
-		assert Vector2D.isUnitVector(axis1X, axis1Y) : "First axis must be a unit vector"; //$NON-NLS-1$
+		assert Vector2D.isUnitVector(axis1X, axis1Y) : FIRST_AXIS_UNIT_VECTOR; //$NON-NLS-1$
 		assert Vector2D.isUnitVector(axis2X, axis2Y) : "Second axis must be a unit vector"; //$NON-NLS-1$
 		assert axis1Extent >= 0. : "Extent for the first axis must be positive or zero"; //$NON-NLS-1$
 		assert axis2Extent >= 0. : "Extent for the first axis must be positive or zero"; //$NON-NLS-1$
@@ -356,7 +363,7 @@ public class Parallelogram2dfx extends AbstractShape2dfx<Parallelogram2dfx>
 
 	@Override
 	public void setFirstAxisExtent(double extent) {
-		assert extent >= 0. : "Extent must be positive or zero"; //$NON-NLS-1$
+		assert extent >= 0. :  EXTENT_POSITIVE_OR_ZERO; //$NON-NLS-1$
 		firstAxisExtentProperty().set(extent);
 	}
 
@@ -387,14 +394,14 @@ public class Parallelogram2dfx extends AbstractShape2dfx<Parallelogram2dfx>
 
 	@Override
 	public void setSecondAxisExtent(double extent) {
-		assert extent >= 0. : "Extent must be positive or zero"; //$NON-NLS-1$
+		assert extent >= 0. :  EXTENT_POSITIVE_OR_ZERO; //$NON-NLS-1$
 		secondAxisExtentProperty().set(extent);
 	}
 
 	@Override
 	public void setFirstAxis(double x, double y, double extent) {
 		assert Vector2D.isUnitVector(x, y) : "Axis must be a unit vector"; //$NON-NLS-1$
-		assert extent >= 0. : "Extent must be positive or zero"; //$NON-NLS-1$
+		assert extent >= 0. :  EXTENT_POSITIVE_OR_ZERO; //$NON-NLS-1$
 		firstAxisProperty().set(x, y);
 		firstAxisExtentProperty().set(extent);
 	}
@@ -402,7 +409,7 @@ public class Parallelogram2dfx extends AbstractShape2dfx<Parallelogram2dfx>
 	@Override
 	public void setSecondAxis(double x, double y, double extent) {
 		assert Vector2D.isUnitVector(x, y) : "Axis must be a unit vector"; //$NON-NLS-1$
-		assert extent >= 0. : "Extent must be positive or zero"; //$NON-NLS-1$
+		assert extent >= 0. :  EXTENT_POSITIVE_OR_ZERO; //$NON-NLS-1$
 		secondAxisProperty().set(x, y);
 		secondAxisExtentProperty().set(extent);
 	}
@@ -410,8 +417,8 @@ public class Parallelogram2dfx extends AbstractShape2dfx<Parallelogram2dfx>
 	@Override
 	public void set(double centerX, double centerY, double axis1x, double axis1y, double axis1Extent, double axis2x,
 			double axis2y, double axis2Extent) {
-		assert Vector2D.isUnitVector(axis1x, axis1y) : "First axis must be a unit vector"; //$NON-NLS-1$
-		assert Vector2D.isUnitVector(axis2x, axis2y) : "First axis must be a unit vector"; //$NON-NLS-1$
+		assert Vector2D.isUnitVector(axis1x, axis1y) : FIRST_AXIS_UNIT_VECTOR; //$NON-NLS-1$
+		assert Vector2D.isUnitVector(axis2x, axis2y) : FIRST_AXIS_UNIT_VECTOR; //$NON-NLS-1$
 		assert axis1Extent >= 0. : "First axis extent must be positive or zero"; //$NON-NLS-1$
 		assert axis2Extent >= 0. : "Second axis extent must be positive or zero"; //$NON-NLS-1$
 		centerXProperty().set(centerX);

--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/Path2dfx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/Path2dfx.java
@@ -59,12 +59,10 @@ import org.arakhne.afc.math.geometry.d2.afp.PathIterator2afp;
 @SuppressWarnings("checkstyle:magicnumber")
 public class Path2dfx extends AbstractShape2dfx<Path2dfx>
 		implements Path2afp<Shape2dfx<?>, Path2dfx, PathElement2dfx, Point2dfx, Vector2dfx, Rectangle2dfx> {
-
 	private static final long serialVersionUID = 6051061640155091109L;
-    /**+
-     * Literal constant.
-     */
-    private static final String PATH_WINDING_RULE = "Path winding rule must be not null";
+
+	private static final String PATH_WINDING_RULE = "Path winding rule must be not null";
+
 	/** Array of types.
 	 */
 	private ReadOnlyListWrapper<PathElementType> types;

--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/Path2dfx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/Path2dfx.java
@@ -61,7 +61,10 @@ public class Path2dfx extends AbstractShape2dfx<Path2dfx>
 		implements Path2afp<Shape2dfx<?>, Path2dfx, PathElement2dfx, Point2dfx, Vector2dfx, Rectangle2dfx> {
 
 	private static final long serialVersionUID = 6051061640155091109L;
-
+    /**+
+     * Literal constant.
+     */
+    private static final String PATH_WINDING_RULE = "Path winding rule must be not null";
 	/** Array of types.
 	 */
 	private ReadOnlyListWrapper<PathElementType> types;
@@ -124,7 +127,7 @@ public class Path2dfx extends AbstractShape2dfx<Path2dfx>
 	 * @param windingRule the path winding rule.
 	 */
 	public Path2dfx(PathWindingRule windingRule) {
-		assert windingRule != null : "Path winding rule must be not null"; //$NON-NLS-1$
+		assert windingRule != null : PATH_WINDING_RULE; //$NON-NLS-1$
 		if (windingRule != DEFAULT_WINDING_RULE) {
 			windingRuleProperty().set(windingRule);
 		}
@@ -135,7 +138,7 @@ public class Path2dfx extends AbstractShape2dfx<Path2dfx>
 	 * @param iterator the iterator that provides the elements to copy.
 	 */
 	public Path2dfx(PathWindingRule windingRule, Iterator<PathElement2dfx> iterator) {
-		assert windingRule != null : "Path winding rule must be not null"; //$NON-NLS-1$
+		assert windingRule != null : PATH_WINDING_RULE; //$NON-NLS-1$
 		assert iterator != null : "Iterator must be not null"; //$NON-NLS-1$
 		if (windingRule != DEFAULT_WINDING_RULE) {
 			windingRuleProperty().set(windingRule);
@@ -314,7 +317,7 @@ public class Path2dfx extends AbstractShape2dfx<Path2dfx>
 
 	@Override
 	public void setWindingRule(PathWindingRule rule) {
-		assert rule != null : "Path winding rule must be not null"; //$NON-NLS-1$
+		assert rule != null : PATH_WINDING_RULE; //$NON-NLS-1$
 		if (this.windingRule != null || rule != DEFAULT_WINDING_RULE) {
 			windingRuleProperty().set(rule);
 		}

--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/Triangle2dfx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/Triangle2dfx.java
@@ -44,12 +44,13 @@ import org.arakhne.afc.math.geometry.d2.afp.Triangle2afp;
 public class Triangle2dfx
 		extends AbstractShape2dfx<Triangle2dfx>
 		implements Triangle2afp<Shape2dfx<?>, Triangle2dfx, PathElement2dfx, Point2dfx, Vector2dfx, Rectangle2dfx> {
-
 	private static final long serialVersionUID = -1872758222696617883L;
-	/**+
+
+	/**
 	 * Literal constant.
 	 */
 	private static final String POINT_ONE_NOT_NULL = "Point 1 must not be null";
+
 	private DoubleProperty x1;
 
 	private DoubleProperty y1;

--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/Triangle2dfx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/Triangle2dfx.java
@@ -46,7 +46,10 @@ public class Triangle2dfx
 		implements Triangle2afp<Shape2dfx<?>, Triangle2dfx, PathElement2dfx, Point2dfx, Vector2dfx, Rectangle2dfx> {
 
 	private static final long serialVersionUID = -1872758222696617883L;
-
+	/**+
+	 * Literal constant.
+	 */
+	private static final String POINT_ONE_NOT_NULL = "Point 1 must not be null";
 	private DoubleProperty x1;
 
 	private DoubleProperty y1;
@@ -73,9 +76,9 @@ public class Triangle2dfx
 	 * @param p3 third point.
 	 */
 	public Triangle2dfx(Point2D<?, ?> p1, Point2D<?, ?> p2, Point2D<?, ?> p3) {
-		assert p1 != null : "Point 1 must not be null"; //$NON-NLS-1$
-		assert p2 != null : "Point 1 must not be null"; //$NON-NLS-1$
-		assert p3 != null : "Point 1 must not be null"; //$NON-NLS-1$
+		assert p1 != null : POINT_ONE_NOT_NULL; //$NON-NLS-1$
+		assert p2 != null : POINT_ONE_NOT_NULL; //$NON-NLS-1$
+		assert p3 != null : POINT_ONE_NOT_NULL; //$NON-NLS-1$
 		set(p1.getX(), p1.getY(), p2.getX(), p2.getY(), p3.getX(), p3.getY());
 	}
 

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/d/Vector2d.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/d/Vector2d.java
@@ -39,6 +39,14 @@ import org.arakhne.afc.math.geometry.d2.Vector2D;
 public class Vector2d extends Tuple2d<Vector2d> implements Vector2D<Vector2d, Point2d> {
 
 	private static final long serialVersionUID = 9183440606977893371L;
+    /**+
+     * Literal constant.
+     */
+	private static final String SECOND_VECTOR_NOT_NULL = "Second vector must be not null";
+    /**+
+     * Literal constant.
+     */
+    private static final String FIRST_VECTOR_NOT_NULL = "First vector must be not null";
 
 	/** Construct a zero vector.
 	 */
@@ -144,8 +152,8 @@ public class Vector2d extends Tuple2d<Vector2d> implements Vector2D<Vector2d, Po
 
 	@Override
 	public void add(Vector2D<?, ?> vector1, Vector2D<?, ?> vector2) {
-		assert vector1 != null : "First vector must be not null"; //$NON-NLS-1$
-		assert vector2 != null : "Second vector must be not null"; //$NON-NLS-1$
+		assert vector1 != null : FIRST_VECTOR_NOT_NULL; //$NON-NLS-1$
+		assert vector2 != null : SECOND_VECTOR_NOT_NULL; //$NON-NLS-1$
 		this.x = vector1.getX() + vector2.getX();
 		this.y = vector1.getY() + vector2.getY();
 	}
@@ -159,16 +167,16 @@ public class Vector2d extends Tuple2d<Vector2d> implements Vector2D<Vector2d, Po
 
 	@Override
 	public void scaleAdd(int scale, Vector2D<?, ?> vector1, Vector2D<?, ?> vector2) {
-		assert vector1 != null : "First vector must be not null"; //$NON-NLS-1$
-		assert vector2 != null : "Second vector must be not null"; //$NON-NLS-1$
+		assert vector1 != null : FIRST_VECTOR_NOT_NULL; //$NON-NLS-1$
+		assert vector2 != null : SECOND_VECTOR_NOT_NULL; //$NON-NLS-1$
 		this.x = scale * vector1.getX() + vector2.getX();
 		this.y = scale * vector1.getY() + vector2.getY();
 	}
 
 	@Override
 	public void scaleAdd(double scale, Vector2D<?, ?> vector1, Vector2D<?, ?> vector2) {
-		assert vector1 != null : "First vector must be not null"; //$NON-NLS-1$
-		assert vector2 != null : "Second vector must be not null"; //$NON-NLS-1$
+		assert vector1 != null : FIRST_VECTOR_NOT_NULL; //$NON-NLS-1$
+		assert vector2 != null : SECOND_VECTOR_NOT_NULL; //$NON-NLS-1$
 		this.x = scale * vector1.getX() + vector2.getX();
 		this.y = scale * vector1.getY() + vector2.getY();
 	}
@@ -189,8 +197,8 @@ public class Vector2d extends Tuple2d<Vector2d> implements Vector2D<Vector2d, Po
 
 	@Override
 	public void sub(Vector2D<?, ?> vector1, Vector2D<?, ?> vector2) {
-		assert vector1 != null : "First vector must be not null"; //$NON-NLS-1$
-		assert vector2 != null : "Second vector must be not null"; //$NON-NLS-1$
+		assert vector1 != null : FIRST_VECTOR_NOT_NULL; //$NON-NLS-1$
+		assert vector2 != null : SECOND_VECTOR_NOT_NULL; //$NON-NLS-1$
 		this.x = vector1.getX() - vector2.getX();
 		this.y = vector1.getY() - vector2.getY();
 	}

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/d/Vector2d.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/d/Vector2d.java
@@ -37,14 +37,15 @@ import org.arakhne.afc.math.geometry.d2.Vector2D;
  * @since 13.0
  */
 public class Vector2d extends Tuple2d<Vector2d> implements Vector2D<Vector2d, Point2d> {
-
 	private static final long serialVersionUID = 9183440606977893371L;
-    /**+
-     * Literal constant.
+
+	/**
+	 *Literal constant.
      */
 	private static final String SECOND_VECTOR_NOT_NULL = "Second vector must be not null";
-    /**+
-     * Literal constant.
+
+    /**
+     *Literal constant.
      */
     private static final String FIRST_VECTOR_NOT_NULL = "First vector must be not null";
 


### PR DESCRIPTION
  This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1192 - “String literals should not be duplicated”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1192
 Please let me know if you have any questions.
Fevzi Ozgul

<!---
@huboard:{"milestone_order":67.0,"order":0.4150390625,"custom_state":""}
-->
