### PR TITLE
Fixing squid: S1192 String literals should not be duplicated Fix 6

### DIFF
--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/ifx/Path2ifx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/ifx/Path2ifx.java
@@ -58,6 +58,10 @@ public class Path2ifx extends AbstractShape2ifx<Path2ifx>
 		implements Path2ai<Shape2ifx<?>, Path2ifx, PathElement2ifx, Point2ifx, Vector2ifx, Rectangle2ifx> {
 
 	private static final long serialVersionUID = -5410743023218999966L;
+	/**+
+	 * Literal constant.
+	 */
+	private static final String PATH_WINDING_RULE = "Path winding rule must be not null";
 
 	/** Array of types.
 	 */
@@ -117,7 +121,7 @@ public class Path2ifx extends AbstractShape2ifx<Path2ifx>
 	 * @param windingRule the path winding rule.
 	 */
 	public Path2ifx(PathWindingRule windingRule) {
-		assert windingRule != null : "Path winding rule must be not null"; //$NON-NLS-1$
+		assert windingRule != null : PATH_WINDING_RULE; //$NON-NLS-1$
 		if (windingRule != DEFAULT_WINDING_RULE) {
 			windingRuleProperty().set(windingRule);
 		}
@@ -128,7 +132,7 @@ public class Path2ifx extends AbstractShape2ifx<Path2ifx>
 	 * @param iterator the iterator that provides the elements to copy.
 	 */
 	public Path2ifx(PathWindingRule windingRule, Iterator<PathElement2ifx> iterator) {
-		assert windingRule != null : "Path winding rule must be not null"; //$NON-NLS-1$
+		assert windingRule != null : PATH_WINDING_RULE; //$NON-NLS-1$
 		assert iterator != null : "Iterator must be not null"; //$NON-NLS-1$
 		if (windingRule != DEFAULT_WINDING_RULE) {
 			windingRuleProperty().set(windingRule);
@@ -342,7 +346,7 @@ public class Path2ifx extends AbstractShape2ifx<Path2ifx>
 
 	@Override
 	public void setWindingRule(PathWindingRule rule) {
-		assert rule != null : "Path winding rule must be not null"; //$NON-NLS-1$
+		assert rule != null : PATH_WINDING_RULE; //$NON-NLS-1$
 		if (this.windingRule != null || rule != DEFAULT_WINDING_RULE) {
 			windingRuleProperty().set(rule);
 		}

--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/ifx/Path2ifx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/ifx/Path2ifx.java
@@ -56,9 +56,9 @@ import org.arakhne.afc.math.geometry.d2.ai.PathIterator2ai;
  */
 public class Path2ifx extends AbstractShape2ifx<Path2ifx>
 		implements Path2ai<Shape2ifx<?>, Path2ifx, PathElement2ifx, Point2ifx, Vector2ifx, Rectangle2ifx> {
-
 	private static final long serialVersionUID = -5410743023218999966L;
-	/**+
+
+	/**
 	 * Literal constant.
 	 */
 	private static final String PATH_WINDING_RULE = "Path winding rule must be not null";

--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/ifx/PathElement2ifx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/ifx/PathElement2ifx.java
@@ -43,7 +43,26 @@ import org.arakhne.afc.math.geometry.d2.ai.PathElement2ai;
 public abstract class PathElement2ifx implements PathElement2ai {
 
 	private static final long serialVersionUID = -5532787413347691238L;
-
+    /**+
+     * Literal constant.
+     */
+    private static final String IS_EMPTY = "isEmpty";
+    /**+
+     * Literal constant.
+     */
+    private static final String ARRAY_NOT_NULL = "Array must be not null";
+    /**+
+     * Literal constant.
+     */
+    private static final String ARRAY_SIZE_SMALL = "Array size is too small";
+    /**+
+     * Literal constant.
+     */
+    private static final String FROMX_NOT_NULL = "Property fromX must be not null";
+    /**+
+     * Literal constant.
+     */
+    private static final String FROMY_NOT_NULL = "Property fromY must be not null";
 	/** Type of the element.
 	 */
 	protected final PathElementType type;
@@ -336,7 +355,7 @@ public abstract class PathElement2ifx implements PathElement2ai {
 		@Override
 		public BooleanProperty isEmptyProperty() {
 			if (this.isEmpty == null) {
-				this.isEmpty = new ReadOnlyBooleanWrapper(this, "isEmpty", true); //$NON-NLS-1$
+				this.isEmpty = new ReadOnlyBooleanWrapper(this, IS_EMPTY, true); //$NON-NLS-1$
 			}
 			return this.isEmpty;
 		}
@@ -350,8 +369,8 @@ public abstract class PathElement2ifx implements PathElement2ai {
 		@Pure
 		@Override
 		public void toArray(int[] array) {
-			assert array != null : "Array must be not null"; //$NON-NLS-1$
-			assert array.length >= 2 : "Size of the array is too small"; //$NON-NLS-1$
+			assert array != null : ARRAY_NOT_NULL; //$NON-NLS-1$
+			assert array.length >= 2 :  ARRAY_SIZE_SMALL; //$NON-NLS-1$
 			array[0] = this.toX.get();
 			array[1] = this.toY.get();
 		}
@@ -359,8 +378,8 @@ public abstract class PathElement2ifx implements PathElement2ai {
 		@Pure
 		@Override
 		public void toArray(double[] array) {
-			assert array != null : "Array must be not null"; //$NON-NLS-1$
-			assert array.length >= 2 : "Size of the array is too small"; //$NON-NLS-1$
+			assert array != null : ARRAY_NOT_NULL; //$NON-NLS-1$
+			assert array.length >= 2 :  ARRAY_SIZE_SMALL; //$NON-NLS-1$
 			array[0] = this.toX.get();
 			array[1] = this.toY.get();
 		}
@@ -368,8 +387,8 @@ public abstract class PathElement2ifx implements PathElement2ai {
 		@Pure
 		@Override
 		public void toArray(IntegerProperty[] array) {
-			assert array != null : "Array must be not null"; //$NON-NLS-1$
-			assert array.length >= 2 : "Size of the array is too small"; //$NON-NLS-1$
+			assert array != null : ARRAY_NOT_NULL; //$NON-NLS-1$
+			assert array.length >= 2 :  ARRAY_SIZE_SMALL; //$NON-NLS-1$
 			array[0] = this.toX;
 			array[1] = this.toY;
 		}
@@ -438,8 +457,8 @@ public abstract class PathElement2ifx implements PathElement2ai {
 		 */
 		LinePathElement2ifx(IntegerProperty fromx, IntegerProperty fromy, IntegerProperty tox, IntegerProperty toy) {
 			super(PathElementType.LINE_TO, tox, toy);
-			assert fromx != null : "Property fromX must be not null"; //$NON-NLS-1$
-			assert fromy != null : "Property fromY must be not null"; //$NON-NLS-1$
+			assert fromx != null : FROMX_NOT_NULL; //$NON-NLS-1$
+			assert fromy != null : FROMY_NOT_NULL; //$NON-NLS-1$
 			this.fromX = fromx;
 			this.fromY = fromy;
 		}
@@ -476,7 +495,7 @@ public abstract class PathElement2ifx implements PathElement2ai {
 		@Override
 		public BooleanProperty isEmptyProperty() {
 			if (this.isEmpty == null) {
-				this.isEmpty = new ReadOnlyBooleanWrapper(this, "isEmpty"); //$NON-NLS-1$
+				this.isEmpty = new ReadOnlyBooleanWrapper(this, IS_EMPTY); //$NON-NLS-1$
 				this.isEmpty.bind(Bindings.createBooleanBinding(() -> {
 					return fromXProperty().get() == toXProperty().get()
 							&& fromYProperty().get() == toYProperty().get();
@@ -494,8 +513,8 @@ public abstract class PathElement2ifx implements PathElement2ai {
 		@Pure
 		@Override
 		public void toArray(int[] array) {
-			assert array != null : "Array must be not null"; //$NON-NLS-1$
-			assert array.length >= 2 : "Size of the array is too small"; //$NON-NLS-1$
+			assert array != null : ARRAY_NOT_NULL; //$NON-NLS-1$
+			assert array.length >= 2 :  ARRAY_SIZE_SMALL; //$NON-NLS-1$
 			array[0] = this.toX.get();
 			array[1] = this.toY.get();
 		}
@@ -503,8 +522,8 @@ public abstract class PathElement2ifx implements PathElement2ai {
 		@Pure
 		@Override
 		public void toArray(double[] array) {
-			assert array != null : "Array must be not null"; //$NON-NLS-1$
-			assert array.length >= 2 : "Size of the array is too small"; //$NON-NLS-1$
+			assert array != null : ARRAY_NOT_NULL; //$NON-NLS-1$
+			assert array.length >= 2 :  ARRAY_SIZE_SMALL; //$NON-NLS-1$
 			array[0] = this.toX.get();
 			array[1] = this.toY.get();
 		}
@@ -518,8 +537,8 @@ public abstract class PathElement2ifx implements PathElement2ai {
 		@Pure
 		@Override
 		public void toArray(IntegerProperty[] array) {
-			assert array != null : "Array must be not null"; //$NON-NLS-1$
-			assert array.length >= 2 : "Size of the array is too small"; //$NON-NLS-1$
+			assert array != null : ARRAY_NOT_NULL; //$NON-NLS-1$
+			assert array.length >= 2 :  ARRAY_SIZE_SMALL; //$NON-NLS-1$
 			array[0] = this.toX;
 			array[1] = this.toY;
 		}
@@ -589,8 +608,8 @@ public abstract class PathElement2ifx implements PathElement2ai {
 		QuadPathElement2ifx(IntegerProperty fromx, IntegerProperty fromy, IntegerProperty ctrlx,
 				IntegerProperty ctrly, IntegerProperty tox, IntegerProperty toy) {
 			super(PathElementType.QUAD_TO, tox, toy);
-			assert fromx != null : "Property fromX must be not null"; //$NON-NLS-1$
-			assert fromy != null : "Property fromY must be not null"; //$NON-NLS-1$
+			assert fromx != null : FROMX_NOT_NULL; //$NON-NLS-1$
+			assert fromy != null : FROMY_NOT_NULL; //$NON-NLS-1$
 			assert ctrlx != null : "Property ctrlX must be not null"; //$NON-NLS-1$
 			assert ctrly != null : "Property ctrlY must be not null"; //$NON-NLS-1$
 			this.fromX = fromx;
@@ -635,7 +654,7 @@ public abstract class PathElement2ifx implements PathElement2ai {
 		@Override
 		public BooleanProperty isEmptyProperty() {
 			if (this.isEmpty == null) {
-				this.isEmpty = new ReadOnlyBooleanWrapper(this, "isEmpty"); //$NON-NLS-1$
+				this.isEmpty = new ReadOnlyBooleanWrapper(this, IS_EMPTY); //$NON-NLS-1$
 				this.isEmpty.bind(Bindings.createBooleanBinding(() -> {
 					return fromXProperty().get() == toXProperty().get()
 							&& fromYProperty().get() == toYProperty().get()
@@ -655,8 +674,8 @@ public abstract class PathElement2ifx implements PathElement2ai {
 		@Pure
 		@Override
 		public void toArray(int[] array) {
-			assert array != null : "Array must be not null"; //$NON-NLS-1$
-			assert array.length >= 4 : "Size of the array is too small"; //$NON-NLS-1$
+			assert array != null : ARRAY_NOT_NULL; //$NON-NLS-1$
+			assert array.length >= 4 :  ARRAY_SIZE_SMALL; //$NON-NLS-1$
 			array[0] = this.ctrlX.get();
 			array[1] = this.ctrlY.get();
 			array[2] = this.toX.get();
@@ -666,8 +685,8 @@ public abstract class PathElement2ifx implements PathElement2ai {
 		@Pure
 		@Override
 		public void toArray(double[] array) {
-			assert array != null : "Array must be not null"; //$NON-NLS-1$
-			assert array.length >= 4 : "Size of the array is too small"; //$NON-NLS-1$
+			assert array != null : ARRAY_NOT_NULL; //$NON-NLS-1$
+			assert array.length >= 4 :  ARRAY_SIZE_SMALL; //$NON-NLS-1$
 			array[0] = this.ctrlX.get();
 			array[1] = this.ctrlY.get();
 			array[2] = this.toX.get();
@@ -683,8 +702,8 @@ public abstract class PathElement2ifx implements PathElement2ai {
 		@Pure
 		@Override
 		public void toArray(IntegerProperty[] array) {
-			assert array != null : "Array must be not null"; //$NON-NLS-1$
-			assert array.length >= 4 : "Size of the array is too small"; //$NON-NLS-1$
+			assert array != null : ARRAY_NOT_NULL; //$NON-NLS-1$
+			assert array.length >= 4 :  ARRAY_SIZE_SMALL; //$NON-NLS-1$
 			array[0] = this.ctrlX;
 			array[1] = this.ctrlY;
 			array[2] = this.toX;
@@ -788,8 +807,8 @@ public abstract class PathElement2ifx implements PathElement2ai {
 		CurvePathElement2ifx(IntegerProperty fromx, IntegerProperty fromy, IntegerProperty ctrlx1, IntegerProperty ctrly1,
 				IntegerProperty ctrlx2, IntegerProperty ctrly2, IntegerProperty tox, IntegerProperty toy) {
 			super(PathElementType.CURVE_TO, tox, toy);
-			assert fromx != null : "Property fromX must be not null"; //$NON-NLS-1$
-			assert fromy != null : "Property fromY must be not null"; //$NON-NLS-1$
+			assert fromx != null : FROMX_NOT_NULL; //$NON-NLS-1$
+			assert fromy != null : FROMY_NOT_NULL; //$NON-NLS-1$
 			assert ctrlx1 != null : "Property ctrlX1 must be not null"; //$NON-NLS-1$
 			assert ctrly1 != null : "Property ctrlY1 must be not null"; //$NON-NLS-1$
 			assert ctrlx2 != null : "Property ctrlX2 must be not null"; //$NON-NLS-1$
@@ -842,7 +861,7 @@ public abstract class PathElement2ifx implements PathElement2ai {
 		@Override
 		public BooleanProperty isEmptyProperty() {
 			if (this.isEmpty == null) {
-				this.isEmpty = new ReadOnlyBooleanWrapper(this, "isEmpty"); //$NON-NLS-1$
+				this.isEmpty = new ReadOnlyBooleanWrapper(this, IS_EMPTY); //$NON-NLS-1$
 				this.isEmpty.bind(Bindings.createBooleanBinding(() -> {
 					return fromXProperty().get() == toXProperty().get()
 							&& fromYProperty().get() == toYProperty().get()
@@ -864,8 +883,8 @@ public abstract class PathElement2ifx implements PathElement2ai {
 		@Pure
 		@Override
 		public void toArray(int[] array) {
-			assert array != null : "Array must be not null"; //$NON-NLS-1$
-			assert array.length >= 6 : "Size of the array is too small"; //$NON-NLS-1$
+			assert array != null : ARRAY_NOT_NULL; //$NON-NLS-1$
+			assert array.length >= 6 :  ARRAY_SIZE_SMALL; //$NON-NLS-1$
 			array[0] = this.ctrlX1.get();
 			array[1] = this.ctrlY1.get();
 			array[2] = this.ctrlX2.get();
@@ -877,8 +896,8 @@ public abstract class PathElement2ifx implements PathElement2ai {
 		@Pure
 		@Override
 		public void toArray(double[] array) {
-			assert array != null : "Array must be not null"; //$NON-NLS-1$
-			assert array.length >= 6 : "Size of the array is too small"; //$NON-NLS-1$
+			assert array != null : ARRAY_NOT_NULL; //$NON-NLS-1$
+			assert array.length >= 6 :  ARRAY_SIZE_SMALL; //$NON-NLS-1$
 			array[0] = this.ctrlX1.get();
 			array[1] = this.ctrlY1.get();
 			array[2] = this.ctrlX2.get();
@@ -896,8 +915,8 @@ public abstract class PathElement2ifx implements PathElement2ai {
 		@Pure
 		@Override
 		public void toArray(IntegerProperty[] array) {
-			assert array != null : "Array must be not null"; //$NON-NLS-1$
-			assert array.length >= 6 : "Size of the array is too small"; //$NON-NLS-1$
+			assert array != null : ARRAY_NOT_NULL; //$NON-NLS-1$
+			assert array.length >= 6 :  ARRAY_SIZE_SMALL; //$NON-NLS-1$
 			array[0] = this.ctrlX1;
 			array[1] = this.ctrlY1;
 			array[2] = this.ctrlX2;
@@ -1016,8 +1035,8 @@ public abstract class PathElement2ifx implements PathElement2ai {
 		 */
 		ClosePathElement2ifx(IntegerProperty fromx, IntegerProperty fromy, IntegerProperty tox, IntegerProperty toy) {
 			super(PathElementType.CLOSE, tox, toy);
-			assert fromx != null : "Property fromX must be not null"; //$NON-NLS-1$
-			assert fromy != null : "Property fromY must be not null"; //$NON-NLS-1$
+			assert fromx != null : FROMX_NOT_NULL; //$NON-NLS-1$
+			assert fromy != null : FROMY_NOT_NULL; //$NON-NLS-1$
 			this.fromX = fromx;
 			this.fromY = fromy;
 
@@ -1055,7 +1074,7 @@ public abstract class PathElement2ifx implements PathElement2ai {
 		@Override
 		public BooleanProperty isEmptyProperty() {
 			if (this.isEmpty == null) {
-				this.isEmpty = new ReadOnlyBooleanWrapper(this, "isEmpty"); //$NON-NLS-1$
+				this.isEmpty = new ReadOnlyBooleanWrapper(this, IS_EMPTY); //$NON-NLS-1$
 				this.isEmpty.bind(Bindings.createBooleanBinding(() -> {
 					return fromXProperty().get() == toXProperty().get()
 							&& fromYProperty().get() == toYProperty().get();
@@ -1073,8 +1092,8 @@ public abstract class PathElement2ifx implements PathElement2ai {
 		@Pure
 		@Override
 		public void toArray(int[] array) {
-			assert array != null : "Array must be not null"; //$NON-NLS-1$
-			assert array.length >= 2 : "Size of the array is too small"; //$NON-NLS-1$
+			assert array != null : ARRAY_NOT_NULL; //$NON-NLS-1$
+			assert array.length >= 2 :  ARRAY_SIZE_SMALL; //$NON-NLS-1$
 			array[0] = this.toX.get();
 			array[1] = this.toY.get();
 		}
@@ -1082,8 +1101,8 @@ public abstract class PathElement2ifx implements PathElement2ai {
 		@Pure
 		@Override
 		public void toArray(double[] array) {
-			assert array != null : "Array must be not null"; //$NON-NLS-1$
-			assert array.length >= 2 : "Size of the array is too small"; //$NON-NLS-1$
+			assert array != null : ARRAY_NOT_NULL; //$NON-NLS-1$
+			assert array.length >= 2 :  ARRAY_SIZE_SMALL; //$NON-NLS-1$
 			array[0] = this.toX.get();
 			array[1] = this.toY.get();
 		}
@@ -1097,8 +1116,8 @@ public abstract class PathElement2ifx implements PathElement2ai {
 		@Pure
 		@Override
 		public void toArray(IntegerProperty[] array) {
-			assert array != null : "Array must be not null"; //$NON-NLS-1$
-			assert array.length >= 2 : "Size of the array is too small"; //$NON-NLS-1$
+			assert array != null : ARRAY_NOT_NULL; //$NON-NLS-1$
+			assert array.length >= 2 :  ARRAY_SIZE_SMALL; //$NON-NLS-1$
 			array[0] = this.toX;
 			array[1] = this.toY;
 		}
@@ -1230,7 +1249,7 @@ public abstract class PathElement2ifx implements PathElement2ai {
 		@Override
 		public BooleanProperty isEmptyProperty() {
 			if (this.isEmpty == null) {
-				this.isEmpty = new ReadOnlyBooleanWrapper(this, "isEmpty"); //$NON-NLS-1$
+				this.isEmpty = new ReadOnlyBooleanWrapper(this, IS_EMPTY); //$NON-NLS-1$
 				this.isEmpty.bind(Bindings.createBooleanBinding(() -> {
 					return fromXProperty().get() == toXProperty().get()
 							&& fromYProperty().get() == toYProperty().get();
@@ -1248,8 +1267,8 @@ public abstract class PathElement2ifx implements PathElement2ai {
 		@Pure
 		@Override
 		public void toArray(int[] array) {
-			assert array != null : "Array must be not null"; //$NON-NLS-1$
-			assert array.length >= 2 : "Array size is too small"; //$NON-NLS-1$
+			assert array != null : ARRAY_NOT_NULL; //$NON-NLS-1$
+			assert array.length >= 2 :  ARRAY_SIZE_SMALL; //$NON-NLS-1$
 			array[0] = this.toX.intValue();
 			array[1] = this.toY.intValue();
 		}
@@ -1257,8 +1276,8 @@ public abstract class PathElement2ifx implements PathElement2ai {
 		@Pure
 		@Override
 		public void toArray(IntegerProperty[] array) {
-			assert array != null : "Array must be not null"; //$NON-NLS-1$
-			assert array.length >= 2 : "Array size is too small"; //$NON-NLS-1$
+			assert array != null : ARRAY_NOT_NULL; //$NON-NLS-1$
+			assert array.length >= 2 :  ARRAY_SIZE_SMALL; //$NON-NLS-1$
 			array[0] = this.toX;
 			array[1] = this.toY;
 		}
@@ -1266,8 +1285,8 @@ public abstract class PathElement2ifx implements PathElement2ai {
 		@Pure
 		@Override
 		public void toArray(double[] array) {
-			assert array != null : "Array must be not null"; //$NON-NLS-1$
-			assert array.length >= 2 : "Array size is too small"; //$NON-NLS-1$
+			assert array != null : ARRAY_NOT_NULL; //$NON-NLS-1$
+			assert array.length >= 2 :  ARRAY_SIZE_SMALL; //$NON-NLS-1$
 			array[0] = this.toX.doubleValue();
 			array[1] = this.toY.doubleValue();
 		}

--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/ifx/PathElement2ifx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/ifx/PathElement2ifx.java
@@ -43,26 +43,32 @@ import org.arakhne.afc.math.geometry.d2.ai.PathElement2ai;
 public abstract class PathElement2ifx implements PathElement2ai {
 
 	private static final long serialVersionUID = -5532787413347691238L;
-    /**+
+
+	   /**
      * Literal constant.
      */
     private static final String IS_EMPTY = "isEmpty";
-    /**+
+
+    /**
      * Literal constant.
      */
     private static final String ARRAY_NOT_NULL = "Array must be not null";
+
     /**+
      * Literal constant.
      */
     private static final String ARRAY_SIZE_SMALL = "Array size is too small";
-    /**+
+
+	/**
      * Literal constant.
      */
-    private static final String FROMX_NOT_NULL = "Property fromX must be not null";
-    /**+
+	private static final String FROMX_NOT_NULL = "Property fromX must be not null";
+
+	   /**
      * Literal constant.
      */
     private static final String FROMY_NOT_NULL = "Property fromY must be not null";
+
 	/** Type of the element.
 	 */
 	protected final PathElementType type;


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1192 - “String literals should not be duplicated”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1192
 Please let me know if you have any questions.
Fevzi Ozgul

<!---
@huboard:{"milestone_order":69.0,"order":0.396728515625,"custom_state":""}
-->
