### PR TITLE
Fixing squid S1192 String literals should not be duplicated Fix 7

### DIFF
--- a/core/math/src/main/java/org/arakhne/afc/math/matrix/Matrix2d.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/matrix/Matrix2d.java
@@ -46,11 +46,13 @@ import org.arakhne.afc.math.geometry.d2.Vector2D;
 public class Matrix2d implements Serializable, Cloneable {
 
 	private static final long serialVersionUID = -181335987517755500L;
-    /**+
+
+	   /**
      *Literal constant.
      */
     private static final String COLUMN_INDEX_RULE = "Column index must be in [0;1]";
-    /**+
+
+	   /**
      *Literal constant.
      */
     private static final String RESULT_VECTOR = "Result vector must not be null";

--- a/core/math/src/main/java/org/arakhne/afc/math/matrix/Matrix2d.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/matrix/Matrix2d.java
@@ -46,6 +46,14 @@ import org.arakhne.afc.math.geometry.d2.Vector2D;
 public class Matrix2d implements Serializable, Cloneable {
 
 	private static final long serialVersionUID = -181335987517755500L;
+    /**+
+     *Literal constant.
+     */
+    private static final String COLUMN_INDEX_RULE = "Column index must be in [0;1]";
+    /**+
+     *Literal constant.
+     */
+    private static final String RESULT_VECTOR = "Result vector must not be null";
 
 	/**
 	 * The first matrix element in the first row.
@@ -174,7 +182,7 @@ public class Matrix2d implements Serializable, Cloneable {
 	 */
 	public final void setElement(int row, int column, double value) {
 		assert row >= 0 && row < 2 : "Row index must be in [0;1]"; //$NON-NLS-1$
-		assert column >= 0 && column < 2 : "Column index must be in [0;1]"; //$NON-NLS-1$
+		assert column >= 0 && column < 2 : COLUMN_INDEX_RULE; //$NON-NLS-1$
 		switch (row) {
 		case 0:
 			switch (column) {
@@ -221,7 +229,7 @@ public class Matrix2d implements Serializable, Cloneable {
 	@Pure
 	public final double getElement(int row, int column) {
 		assert row >= 0 && row < 2 : "Row index must be in [0;1]"; //$NON-NLS-1$
-		assert column >= 0 && column < 2 : "Column index must be in [0;1]"; //$NON-NLS-1$
+		assert column >= 0 && column < 2 : COLUMN_INDEX_RULE; //$NON-NLS-1$
 		switch (row) {
 		case 0:
 			switch (column) {
@@ -306,7 +314,7 @@ public class Matrix2d implements Serializable, Cloneable {
 	 *            the vector into which the matrix row values will be copied
 	 */
 	public final void getColumn(int column, Tuple2D<?> vector) {
-		assert column >= 0 && column < 2 : "Column index must be in [0;1]"; //$NON-NLS-1$
+		assert column >= 0 && column < 2 : COLUMN_INDEX_RULE; //$NON-NLS-1$
 		assert vector != null : "Value vector must not be null"; //$NON-NLS-1$
 		if (column == 0) {
 			vector.set(this.m00, this.m10);
@@ -327,7 +335,7 @@ public class Matrix2d implements Serializable, Cloneable {
 	 *            the array into which the matrix row values will be copied
 	 */
 	public final void getColumn(int column, double[] vector) {
-		assert column >= 0 && column < 2 : "Column index must be in [0;1]"; //$NON-NLS-1$
+		assert column >= 0 && column < 2 : COLUMN_INDEX_RULE; //$NON-NLS-1$
 		assert vector != null : "Value vector must not be null"; //$NON-NLS-1$
 		assert vector.length >= 2 : "Size of the value vector is too small"; //$NON-NLS-1$
 		if (column == 0) {
@@ -438,7 +446,7 @@ public class Matrix2d implements Serializable, Cloneable {
 	 *            the second row element
 	 */
 	public final void setColumn(int column, double x, double y) {
-		assert column >= 0 && column < 2 : "Column index must be in [0;1]"; //$NON-NLS-1$
+		assert column >= 0 && column < 2 : COLUMN_INDEX_RULE; //$NON-NLS-1$
 		switch (column) {
 		case 0:
 			this.m00 = x;
@@ -465,7 +473,7 @@ public class Matrix2d implements Serializable, Cloneable {
 	 *            the replacement column
 	 */
 	public final void setColumn(int column, Tuple2D<?> vector) {
-		assert column >= 0 && column < 2 : "Column index must be in [0;1]"; //$NON-NLS-1$
+		assert column >= 0 && column < 2 : COLUMN_INDEX_RULE; //$NON-NLS-1$
 		assert vector != null : "Value vector must not be null"; //$NON-NLS-1$
 		switch (column) {
 		case 0:
@@ -493,7 +501,7 @@ public class Matrix2d implements Serializable, Cloneable {
 	 *            the replacement column
 	 */
 	public final void setColumn(int column, double[] vector) {
-		assert column >= 0 && column < 2 : "Column index must be in [0;1]"; //$NON-NLS-1$
+		assert column >= 0 && column < 2 : COLUMN_INDEX_RULE; //$NON-NLS-1$
 		assert vector != null : "Value vector must not be null"; //$NON-NLS-1$
 		assert vector.length >= 2 : "Size of the value vector is too small"; //$NON-NLS-1$
 		switch (column) {
@@ -1213,7 +1221,7 @@ public class Matrix2d implements Serializable, Cloneable {
 	 * @return <code>true</code> if the covariance matrix could be computed.
 	 */
 	public final boolean cov(Vector2D<?, ?> result, Vector2D<?, ?>... tuples) {
-		assert result != null : "Result vector must not be null"; //$NON-NLS-1$
+		assert result != null : RESULT_VECTOR; //$NON-NLS-1$
 		assert tuples != null : "List of tuples must be not null"; //$NON-NLS-1$
 		return cov(result, Arrays.asList(tuples));
 	}
@@ -1226,7 +1234,7 @@ public class Matrix2d implements Serializable, Cloneable {
 	 * @return <code>true</code> if the covariance matrix could be computed.
 	 */
 	public final boolean cov(Vector2D<?, ?> result, Point2D<?, ?>... tuples) {
-		assert result != null : "Result vector must not be null"; //$NON-NLS-1$
+		assert result != null : RESULT_VECTOR; //$NON-NLS-1$
 		assert tuples != null : "List of tuples must be not null"; //$NON-NLS-1$
 		return cov(result, Arrays.asList(tuples));
 	}
@@ -1239,7 +1247,7 @@ public class Matrix2d implements Serializable, Cloneable {
 	 * @return <code>true</code> if the covariance matrix could be computed.
 	 */
 	public boolean cov(Vector2D<?, ?> result, Iterable<? extends Tuple2D<?>> tuples) {
-		assert result != null : "Result vector must not be null"; //$NON-NLS-1$
+		assert result != null : RESULT_VECTOR; //$NON-NLS-1$
 		assert tuples != null : "List of tuples must be not null"; //$NON-NLS-1$
 		setZero();
 

--- a/core/math/src/main/java/org/arakhne/afc/math/matrix/Matrix3d.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/matrix/Matrix3d.java
@@ -47,6 +47,18 @@ public class Matrix3d implements Serializable, Cloneable {
 
 	private static final long serialVersionUID = -7386754038391115819L;
 
+    /**+
+     *Literal constant.
+     */
+    private static final String COLUMN_INDEX_RULE = "Column index must be in [0; 2]";
+    /**+
+     *Literal constant.
+     */
+    private static final String SECOND_MATRIX_NOT_NULL = "Second matrix must not be null";
+    /**+
+     *Literal constant.
+     */
+    private static final String FIRST_MATRIX_NOT_NULL = "First matrix must not be null";
 	/**
 	 * The first matrix element in the first row.
 	 */
@@ -244,7 +256,7 @@ public class Matrix3d implements Serializable, Cloneable {
 	 */
 	public void setElement(int row, int column, double value) {
 		assert row >= 0 && row < 3 : "Row index must be in [0; 2]"; //$NON-NLS-1$
-		assert column >= 0 && column < 3 : "Column index must be in [0; 2]"; //$NON-NLS-1$
+		assert column >= 0 && column < 3 : COLUMN_INDEX_RULE; //$NON-NLS-1$
 		switch (row) {
 		case 0:
 			switch (column) {
@@ -315,7 +327,7 @@ public class Matrix3d implements Serializable, Cloneable {
 	@SuppressWarnings("checkstyle:returncount")
 	public double getElement(int row, int column) {
 		assert row >= 0 && row < 3 : "Row index must be in [0; 2]"; //$NON-NLS-1$
-		assert column >= 0 && column < 3 : "Column index must be in [0; 2]"; //$NON-NLS-1$
+		assert column >= 0 && column < 3 : COLUMN_INDEX_RULE; //$NON-NLS-1$
 		switch (row) {
 		case 0:
 			switch (column) {
@@ -425,7 +437,7 @@ public class Matrix3d implements Serializable, Cloneable {
 	 *            the vector into which the matrix row values will be copied
 	 */
 	public void getColumn(int column, Vector3D vector) {
-		assert column >= 0 && column < 3 : "Column index must be in [0; 2]"; //$NON-NLS-1$
+		assert column >= 0 && column < 3 : COLUMN_INDEX_RULE; //$NON-NLS-1$
 		assert vector != null : "Vector of values must not be null"; //$NON-NLS-1$
 		if (column == 0) {
 			vector.set(this.m00, this.m10, this.m20);
@@ -449,7 +461,7 @@ public class Matrix3d implements Serializable, Cloneable {
 	 *            the array into which the matrix row values will be copied
 	 */
 	public void getColumn(int column, double[] vector) {
-		assert column >= 0 && column < 3 : "Column index must be in [0; 2]"; //$NON-NLS-1$
+		assert column >= 0 && column < 3 : COLUMN_INDEX_RULE; //$NON-NLS-1$
 		assert vector != null : "Vector of values must not be null"; //$NON-NLS-1$
 		assert vector.length >= 3 : "Size of the vector is too small";  //$NON-NLS-1$
 		if (column == 0) {
@@ -598,7 +610,7 @@ public class Matrix3d implements Serializable, Cloneable {
 	 *            the third row element
 	 */
 	public void setColumn(int column, double x, double y, double z) {
-		assert column >= 0 && column < 3 : "Column index must be in [0; 2]"; //$NON-NLS-1$
+		assert column >= 0 && column < 3 : COLUMN_INDEX_RULE; //$NON-NLS-1$
 		switch (column) {
 		case 0:
 			this.m00 = x;
@@ -634,7 +646,7 @@ public class Matrix3d implements Serializable, Cloneable {
 	 *            the replacement column
 	 */
 	public void setColumn(int column, Vector3D vector) {
-		assert column >= 0 && column < 3 : "Column index must be in [0; 2]"; //$NON-NLS-1$
+		assert column >= 0 && column < 3 : COLUMN_INDEX_RULE; //$NON-NLS-1$
 		assert vector != null : "Vector of values must not be null"; //$NON-NLS-1$
 		switch (column) {
 		case 0:
@@ -671,7 +683,7 @@ public class Matrix3d implements Serializable, Cloneable {
 	 *            the replacement column
 	 */
 	public void setColumn(int column, double[] vector) {
-		assert column >= 0 && column < 3 : "Column index must be in [0; 2]"; //$NON-NLS-1$
+		assert column >= 0 && column < 3 : COLUMN_INDEX_RULE; //$NON-NLS-1$
 		assert vector != null : "Vector of values must not be null"; //$NON-NLS-1$
 		assert vector.length >= 3 : "Size of the vector is too small";  //$NON-NLS-1$
 		switch (column) {
@@ -757,8 +769,8 @@ public class Matrix3d implements Serializable, Cloneable {
 	 *            the second matrix
 	 */
 	public void add(Matrix3d matrix1, Matrix3d matrix2) {
-		assert matrix1 != null : "First matrix must not be null"; //$NON-NLS-1$
-		assert matrix2 != null : "Second matrix must not be null"; //$NON-NLS-1$
+		assert matrix1 != null : FIRST_MATRIX_NOT_NULL; //$NON-NLS-1$
+		assert matrix2 != null : SECOND_MATRIX_NOT_NULL; //$NON-NLS-1$
 		this.m00 = matrix1.m00 + matrix2.m00;
 		this.m01 = matrix1.m01 + matrix2.m01;
 		this.m02 = matrix1.m02 + matrix2.m02;
@@ -807,8 +819,8 @@ public class Matrix3d implements Serializable, Cloneable {
 	 *            the second matrix
 	 */
 	public void sub(Matrix3d matrix1, Matrix3d matrix2) {
-		assert matrix1 != null : "First matrix must not be null"; //$NON-NLS-1$
-		assert matrix2 != null : "Second matrix must not be null"; //$NON-NLS-1$
+		assert matrix1 != null : FIRST_MATRIX_NOT_NULL; //$NON-NLS-1$
+		assert matrix2 != null : SECOND_MATRIX_NOT_NULL; //$NON-NLS-1$
 		this.m00 = matrix1.m00 - matrix2.m00;
 		this.m01 = matrix1.m01 - matrix2.m01;
 		this.m02 = matrix1.m02 - matrix2.m02;
@@ -1378,8 +1390,8 @@ public class Matrix3d implements Serializable, Cloneable {
 	 *            the second matrix
 	 */
 	public void mul(Matrix3d matrix1, Matrix3d matrix2) {
-		assert matrix1 != null : "First matrix must not be null"; //$NON-NLS-1$
-		assert matrix2 != null : "Second matrix must not be null"; //$NON-NLS-1$
+		assert matrix1 != null : FIRST_MATRIX_NOT_NULL; //$NON-NLS-1$
+		assert matrix2 != null : SECOND_MATRIX_NOT_NULL; //$NON-NLS-1$
 		if (this != matrix1 && this != matrix2) {
 			this.m00 = matrix1.m00 * matrix2.m00 + matrix1.m01 * matrix2.m10 + matrix1.m02 * matrix2.m20;
 			this.m01 = matrix1.m00 * matrix2.m01 + matrix1.m01 * matrix2.m11 + matrix1.m02 * matrix2.m21;
@@ -1459,8 +1471,8 @@ public class Matrix3d implements Serializable, Cloneable {
 	 *            the matrix on the right hand side of the multiplication
 	 */
 	public void mulTransposeLeft(Matrix3d matrix1, Matrix3d matrix2) {
-		assert matrix1 != null : "First matrix must not be null"; //$NON-NLS-1$
-		assert matrix2 != null : "Second matrix must not be null"; //$NON-NLS-1$
+		assert matrix1 != null : FIRST_MATRIX_NOT_NULL; //$NON-NLS-1$
+		assert matrix2 != null : SECOND_MATRIX_NOT_NULL; //$NON-NLS-1$
 		if (this != matrix1 && this != matrix2) {
 			this.m00 = matrix1.m00 * matrix2.m00 + matrix1.m10 * matrix2.m10 + matrix1.m20 * matrix2.m20;
 			this.m01 = matrix1.m00 * matrix2.m01 + matrix1.m10 * matrix2.m11 + matrix1.m20 * matrix2.m21;
@@ -1554,8 +1566,8 @@ public class Matrix3d implements Serializable, Cloneable {
 	 *            the matrix on the right hand side of the multiplication
 	 */
 	public void mulNormalize(Matrix3d matrix1, Matrix3d matrix2) {
-		assert matrix1 != null : "First matrix must not be null"; //$NON-NLS-1$
-		assert matrix2 != null : "Second matrix must not be null"; //$NON-NLS-1$
+		assert matrix1 != null : FIRST_MATRIX_NOT_NULL; //$NON-NLS-1$
+		assert matrix2 != null : SECOND_MATRIX_NOT_NULL; //$NON-NLS-1$
 
 		final double[] tmp = new double[9];
 		final double[] tmpRot = new double[9];
@@ -1600,8 +1612,8 @@ public class Matrix3d implements Serializable, Cloneable {
 	 *            the matrix on the right hand side of the multiplication
 	 */
 	public void mulTransposeBoth(Matrix3d matrix1, Matrix3d matrix2) {
-		assert matrix1 != null : "First matrix must not be null"; //$NON-NLS-1$
-		assert matrix2 != null : "Second matrix must not be null"; //$NON-NLS-1$
+		assert matrix1 != null : FIRST_MATRIX_NOT_NULL; //$NON-NLS-1$
+		assert matrix2 != null : SECOND_MATRIX_NOT_NULL; //$NON-NLS-1$
 		if (this != matrix1 && this != matrix2) {
 			this.m00 = matrix1.m00 * matrix2.m00 + matrix1.m10 * matrix2.m01 + matrix1.m20 * matrix2.m02;
 			this.m01 = matrix1.m00 * matrix2.m10 + matrix1.m10 * matrix2.m11 + matrix1.m20 * matrix2.m12;
@@ -1651,8 +1663,8 @@ public class Matrix3d implements Serializable, Cloneable {
 	 *            the matrix on the right hand side of the multiplication
 	 */
 	public void mulTransposeRight(Matrix3d matrix1, Matrix3d matrix2) {
-		assert matrix1 != null : "First matrix must not be null"; //$NON-NLS-1$
-		assert matrix2 != null : "Second matrix must not be null"; //$NON-NLS-1$
+		assert matrix1 != null : FIRST_MATRIX_NOT_NULL; //$NON-NLS-1$
+		assert matrix2 != null : SECOND_MATRIX_NOT_NULL; //$NON-NLS-1$
 		if (this != matrix1 && this != matrix2) {
 			this.m00 = matrix1.m00 * matrix2.m00 + matrix1.m01 * matrix2.m01 + matrix1.m02 * matrix2.m02;
 			this.m01 = matrix1.m00 * matrix2.m10 + matrix1.m01 * matrix2.m11 + matrix1.m02 * matrix2.m12;

--- a/core/math/src/main/java/org/arakhne/afc/math/matrix/Matrix3d.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/matrix/Matrix3d.java
@@ -45,20 +45,23 @@ import org.arakhne.afc.vmutil.locale.Locale;
 @SuppressWarnings({"checkstyle:magicnumber", "checkstyle:methodcount"})
 public class Matrix3d implements Serializable, Cloneable {
 
-	private static final long serialVersionUID = -7386754038391115819L;
+    private static final long serialVersionUID = -7386754038391115819L;
 
-    /**+
-     *Literal constant.
-     */
+   	/**
+	 * Literal constant.
+	 */
     private static final String COLUMN_INDEX_RULE = "Column index must be in [0; 2]";
-    /**+
+
+	   /**
      *Literal constant.
      */
     private static final String SECOND_MATRIX_NOT_NULL = "Second matrix must not be null";
-    /**+
+
+	   /**
      *Literal constant.
      */
     private static final String FIRST_MATRIX_NOT_NULL = "First matrix must not be null";
+
 	/**
 	 * The first matrix element in the first row.
 	 */

--- a/core/math/src/main/java/org/arakhne/afc/math/matrix/Matrix4d.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/matrix/Matrix4d.java
@@ -39,7 +39,22 @@ import org.arakhne.afc.math.MathUtil;
 public class Matrix4d implements Serializable, Cloneable {
 
 	private static final long serialVersionUID = 7216873052550769543L;
-
+	/**+
+	 *Literal constant.
+	 */
+	private static final String COLUMN_INDEX_RULE = "Column number must be in [0; 4]";
+	/**+
+	 *Literal constant.
+	 */
+	private static final String SECOND_MATRIX_NOT_NULL = "Second matrix must not be null";
+	/**+
+	 *Literal constant.
+	 */
+	private static final String FIRST_MATRIX_NOT_NULL = "First matrix must not be null";
+	/**+
+	 *Literal constant.
+	 */
+	private static final String ARRAY_SIZE_TOO_SMALL = "Size of the array of values is too small";
 	/**
 	 * The first matrix element in the first row.
 	 */
@@ -338,7 +353,7 @@ public class Matrix4d implements Serializable, Cloneable {
 	@SuppressWarnings("checkstyle:cyclomaticcomplexity")
 	public final void setElement(int row, int column, double value) {
 		assert row >= 0 && row < 4 : "Row number must be in [0; 4]"; //$NON-NLS-1$
-		assert column >= 0 && column < 4 : "Column number must be in [0; 4]"; //$NON-NLS-1$
+		assert column >= 0 && column < 4 :  COLUMN_INDEX_RULE; //$NON-NLS-1$
 		switch (row) {
 		case 0:
 			switch (column) {
@@ -437,7 +452,7 @@ public class Matrix4d implements Serializable, Cloneable {
 	@SuppressWarnings({"checkstyle:returncount", "checkstyle:cyclomaticcomplexity"})
 	public final double getElement(int row, int column) {
 		assert row >= 0 && row < 4 : "Row number must be in [0; 4]"; //$NON-NLS-1$
-		assert column >= 0 && column < 4 : "Column number must be in [0; 4]"; //$NON-NLS-1$
+		assert column >= 0 && column < 4 :  COLUMN_INDEX_RULE; //$NON-NLS-1$
 		switch (row) {
 		case 0:
 			switch (column) {
@@ -516,7 +531,7 @@ public class Matrix4d implements Serializable, Cloneable {
 	public final void getRow(int row, double[] v) {
 		assert row >= 0 && row < 4 : "Row number must be in [0; 4]"; //$NON-NLS-1$
 		assert v != null : "Array of values must not be null"; //$NON-NLS-1$
-		assert v.length >= 4 : "Size of the array of values is too small"; //$NON-NLS-1$
+		assert v.length >= 4 : ARRAY_SIZE_TOO_SMALL; //$NON-NLS-1$
 		if (row == 0) {
 			v[0] = this.m00;
 			v[1] = this.m01;
@@ -553,9 +568,9 @@ public class Matrix4d implements Serializable, Cloneable {
 	 *            the array into which the matrix row values will be copied
 	 */
 	public final void getColumn(int column, double[] v) {
-		assert column >= 0 && column < 4 : "Column number must be in [0; 4]"; //$NON-NLS-1$
+		assert column >= 0 && column < 4 :  COLUMN_INDEX_RULE; //$NON-NLS-1$
 		assert v != null : "Array of values must not be null"; //$NON-NLS-1$
-		assert v.length >= 4 : "Size of the array of values is too small"; //$NON-NLS-1$
+		assert v.length >= 4 : ARRAY_SIZE_TOO_SMALL; //$NON-NLS-1$
 		if (column == 0) {
 			v[0] = this.m00;
 			v[1] = this.m10;
@@ -645,7 +660,7 @@ public class Matrix4d implements Serializable, Cloneable {
 	public final void setRow(int row, double[] v) {
 		assert row >= 0 && row < 4 : "Row number must be in [0; 4]"; //$NON-NLS-1$
 		assert v != null : "Array of values must not be null"; //$NON-NLS-1$
-		assert v.length >= 4 : "Size of the array of values is too small"; //$NON-NLS-1$
+		assert v.length >= 4 : ARRAY_SIZE_TOO_SMALL; //$NON-NLS-1$
 		switch (row) {
 		case 0:
 			this.m00 = v[0];
@@ -697,7 +712,7 @@ public class Matrix4d implements Serializable, Cloneable {
 	 *            the fourth row element
 	 */
 	public final void setColumn(int column, double value1, double value2, double value3, double value4) {
-		assert column >= 0 && column < 4 : "Column number must be in [0; 4]"; //$NON-NLS-1$
+		assert column >= 0 && column < 4 :  COLUMN_INDEX_RULE; //$NON-NLS-1$
 		switch (column) {
 		case 0:
 			this.m00 = value1;
@@ -743,9 +758,9 @@ public class Matrix4d implements Serializable, Cloneable {
 	 *            the replacement column
 	 */
 	public final void setColumn(int column, double[] v) {
-		assert column >= 0 && column < 4 : "Column number must be in [0; 4]"; //$NON-NLS-1$
+		assert column >= 0 && column < 4 :  COLUMN_INDEX_RULE; //$NON-NLS-1$
 		assert v != null : "Array of values must not be null"; //$NON-NLS-1$
-		assert v.length >= 4 : "Size of the array of values is too small"; //$NON-NLS-1$
+		assert v.length >= 4 : ARRAY_SIZE_TOO_SMALL; //$NON-NLS-1$
 		switch (column) {
 		case 0:
 			this.m00 = v[0];
@@ -855,8 +870,8 @@ public class Matrix4d implements Serializable, Cloneable {
 	 *            the second matrix
 	 */
 	public final void add(Matrix4d matrix1, Matrix4d matrix2) {
-		assert matrix1 != null : "First matrix must not be null"; //$NON-NLS-1$
-		assert matrix2 != null : "Second matrix must not be null"; //$NON-NLS-1$
+		assert matrix1 != null :  FIRST_MATRIX_NOT_NULL; //$NON-NLS-1$
+		assert matrix2 != null : SECOND_MATRIX_NOT_NULL; //$NON-NLS-1$
 		this.m00 = matrix1.m00 + matrix2.m00;
 		this.m01 = matrix1.m01 + matrix2.m01;
 		this.m02 = matrix1.m02 + matrix2.m02;
@@ -921,8 +936,8 @@ public class Matrix4d implements Serializable, Cloneable {
 	 *            the second matrix
 	 */
 	public final void sub(Matrix4d matrix1, Matrix4d matrix2) {
-		assert matrix1 != null : "First matrix must not be null"; //$NON-NLS-1$
-		assert matrix2 != null : "Second matrix must not be null"; //$NON-NLS-1$
+		assert matrix1 != null :  FIRST_MATRIX_NOT_NULL; //$NON-NLS-1$
+		assert matrix2 != null : SECOND_MATRIX_NOT_NULL; //$NON-NLS-1$
 		this.m00 = matrix1.m00 - matrix2.m00;
 		this.m01 = matrix1.m01 - matrix2.m01;
 		this.m02 = matrix1.m02 - matrix2.m02;
@@ -1334,8 +1349,8 @@ public class Matrix4d implements Serializable, Cloneable {
 	 *            the second matrix
 	 */
 	public final void mul(Matrix4d matrix1, Matrix4d matrix2) {
-		assert matrix1 != null : "First matrix must not be null"; //$NON-NLS-1$
-		assert matrix2 != null : "Second matrix must not be null"; //$NON-NLS-1$
+		assert matrix1 != null :  FIRST_MATRIX_NOT_NULL; //$NON-NLS-1$
+		assert matrix2 != null : SECOND_MATRIX_NOT_NULL; //$NON-NLS-1$
 		if (this != matrix1 && this != matrix2) {
 			this.m00 = matrix1.m00 * matrix2.m00 + matrix1.m01 * matrix2.m10
 					+ matrix1.m02 * matrix2.m20 + matrix1.m03 * matrix2.m30;
@@ -1724,7 +1739,7 @@ public class Matrix4d implements Serializable, Cloneable {
 	 *            the source matrix
 	 */
 	public final void negate(Matrix4d matrix) {
-		assert matrix != null : "First matrix must not be null"; //$NON-NLS-1$
+		assert matrix != null :  FIRST_MATRIX_NOT_NULL; //$NON-NLS-1$
 		this.m00 = -matrix.m00;
 		this.m01 = -matrix.m01;
 		this.m02 = -matrix.m02;

--- a/core/math/src/main/java/org/arakhne/afc/math/matrix/Matrix4d.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/matrix/Matrix4d.java
@@ -39,22 +39,27 @@ import org.arakhne.afc.math.MathUtil;
 public class Matrix4d implements Serializable, Cloneable {
 
 	private static final long serialVersionUID = 7216873052550769543L;
-	/**+
+
+	/**
 	 *Literal constant.
 	 */
 	private static final String COLUMN_INDEX_RULE = "Column number must be in [0; 4]";
-	/**+
+
+	/**
 	 *Literal constant.
 	 */
 	private static final String SECOND_MATRIX_NOT_NULL = "Second matrix must not be null";
-	/**+
+
+	/**
 	 *Literal constant.
 	 */
 	private static final String FIRST_MATRIX_NOT_NULL = "First matrix must not be null";
-	/**+
+
+	/**
 	 *Literal constant.
 	 */
 	private static final String ARRAY_SIZE_TOO_SMALL = "Size of the array of values is too small";
+
 	/**
 	 * The first matrix element in the first row.
 	 */


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1192 - “String literals should not be duplicated”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1192
 Please let me know if you have any questions.
Fevzi Ozgul

<!---
@huboard:{"milestone_order":70.0,"order":0.3936767578125,"custom_state":""}
-->
