### PR TITLE
Fixing squid:ForLoopCounterChangedCheck  for loop stop conditions should be invariant fix 2

### DIFF
--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/Path2dfx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/Path2dfx.java
@@ -536,7 +536,7 @@ public class Path2dfx extends AbstractShape2dfx<Path2dfx>
 			} else {
 				final Point2D<?, ?> p = new InnerComputationPoint2afp();
 				final Iterator<Double> iterator = this.coords.iterator();
-				for (int i = 0; i < n; i =+ 2) {
+				for (int i = 0; i < n; i += 2) {
 					p.set(iterator.next(), iterator.next());
 					transform.transform(p);
 					clone[i] = p.getX();

--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/Path2dfx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/Path2dfx.java
@@ -155,9 +155,9 @@ public class Path2dfx extends AbstractShape2dfx<Path2dfx>
 	public boolean containsControlPoint(Point2D<?, ?> pt) {
 		assert pt != null : "Point must be not null"; //$NON-NLS-1$
 		if (this.coords != null && !this.coords.isEmpty()) {
-			for (int i = 0; i < this.coords.size();) {
-				final double x = this.coords.get(i++);
-				final double y = this.coords.get(i++);
+			for (int i = 0; i < this.coords.size(); i += 2) {
+				final double x = this.coords.get(i);
+				final double y = this.coords.get(i + 1);
 				if (x == pt.getX() && y == pt.getY()) {
 					return true;
 				}
@@ -488,11 +488,11 @@ public class Path2dfx extends AbstractShape2dfx<Path2dfx>
 			} else {
 				final Point2D<?, ?> p = new InnerComputationPoint2afp();
 				final Iterator<Double> iterator = this.coords.iterator();
-				for (int i = 0; i < n;) {
+				for (int i = 0; i < n; i += 2) {
 					p.set(iterator.next(), iterator.next());
 					transform.transform(p);
-					clone[i++] = p.ix();
-					clone[i++] = p.iy();
+					clone[i] = p.ix();
+					clone[i + 1] = p.iy();
 				}
 			}
 		}
@@ -512,11 +512,11 @@ public class Path2dfx extends AbstractShape2dfx<Path2dfx>
 			} else {
 				final Point2D<?, ?> p = new InnerComputationPoint2afp();
 				final Iterator<Double> iterator = this.coords.iterator();
-				for (int i = 0; i < n;) {
+				for (int i = 0; i < n; i += 2) {
 					p.set(iterator.next(), iterator.next());
 					transform.transform(p);
-					clone[i++] = (float) p.getX();
-					clone[i++] = (float) p.getY();
+					clone[i] = (float) p.getX();
+					clone[i + 1] = (float) p.getY();
 				}
 			}
 		}
@@ -536,11 +536,11 @@ public class Path2dfx extends AbstractShape2dfx<Path2dfx>
 			} else {
 				final Point2D<?, ?> p = new InnerComputationPoint2afp();
 				final Iterator<Double> iterator = this.coords.iterator();
-				for (int i = 0; i < n;) {
+				for (int i = 0; i < n; i =+ 2) {
 					p.set(iterator.next(), iterator.next());
 					transform.transform(p);
-					clone[i++] = p.getX();
-					clone[i++] = p.getY();
+					clone[i] = p.getX();
+					clone[i + 1] = p.getY();
 				}
 			}
 		}

--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/ifx/Path2ifx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/ifx/Path2ifx.java
@@ -228,10 +228,10 @@ public class Path2ifx extends AbstractShape2ifx<Path2ifx>
 	public void translate(int dx, int dy) {
 		if (this.coords != null && !this.coords.isEmpty()) {
 			final ListIterator<Integer> li = this.coords.listIterator();
-	        while (li.hasNext()) {
-	            li.set(li.next() + dx);
-	            li.set(li.next() + dy);
-	        }
+			while (li.hasNext()) {
+				li.set(li.next() + dx);
+				li.set(li.next() + dy);
+			}
 		}
 	}
 
@@ -242,12 +242,13 @@ public class Path2ifx extends AbstractShape2ifx<Path2ifx>
 		if (this.coords != null && !this.coords.isEmpty()) {
 			final ListIterator<Integer> li = this.coords.listIterator();
 			int i = 0;
-	        while (li.hasNext()) {
-	        	p.set(li.next(), li.next());
+			while (li.hasNext()) {
+				p.set(li.next(), li.next());
 				transform.transform(p);
-				this.coords.set(i++, p.ix());
-				this.coords.set(i++, p.iy());
-	        }
+				this.coords.set(i, p.ix());
+				this.coords.set(i + 1, p.iy());
+                i += 2;
+			}
 		}
 	}
 

--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/ifx/Path2ifx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/ifx/Path2ifx.java
@@ -149,9 +149,9 @@ public class Path2ifx extends AbstractShape2ifx<Path2ifx>
 		assert pt != null : "Point must be not null"; //$NON-NLS-1$
 		if (this.coords != null && !this.coords.isEmpty()) {
 			final int size = this.coords.size();
-			for (int i = 0; i < size;) {
-				final int x = this.coords.get(i++);
-				final int y = this.coords.get(i++);
+			for (int i = 0; i < size; i =+ 2) {
+				final int x = this.coords.get(i);
+				final int y = this.coords.get(i + 1);
 				if (x == pt.ix() && y == pt.iy()) {
 					return true;
 				}
@@ -501,11 +501,11 @@ public class Path2ifx extends AbstractShape2ifx<Path2ifx>
 			} else {
 				final Point2D<?, ?> p = new InnerComputationPoint2ai();
 				final Iterator<Integer> iterator = this.coords.iterator();
-				for (int i = 0; i < n;) {
+				for (int i = 0; i < n; i += 2) {
 					p.set(iterator.next(), iterator.next());
 					transform.transform(p);
-					clone[i++] = p.ix();
-					clone[i++] = p.iy();
+					clone[i] = p.ix();
+					clone[i + 1] = p.iy();
 				}
 			}
 		}
@@ -525,11 +525,11 @@ public class Path2ifx extends AbstractShape2ifx<Path2ifx>
 			} else {
 				final Point2D<?, ?> p = new InnerComputationPoint2afp(0, 0);
 				final Iterator<Integer> iterator = this.coords.iterator();
-				for (int i = 0; i < n;) {
+				for (int i = 0; i < n; i =+ 2) {
 					p.set(iterator.next(), iterator.next());
 					transform.transform(p);
-					clone[i++] = (float) p.getX();
-					clone[i++] = (float) p.getY();
+					clone[i] = (float) p.getX();
+					clone[i + 1] = (float) p.getY();
 				}
 			}
 		}
@@ -549,11 +549,11 @@ public class Path2ifx extends AbstractShape2ifx<Path2ifx>
 			} else {
 				final Point2D<?, ?> p = new InnerComputationPoint2afp(0, 0);
 				final Iterator<Integer> iterator = this.coords.iterator();
-				for (int i = 0; i < n;) {
+				for (int i = 0; i < n; i =+ 2) {
 					p.set(iterator.next(), iterator.next());
 					transform.transform(p);
-					clone[i++] = p.getX();
-					clone[i++] = p.getY();
+					clone[i] = p.getX();
+					clone[i + 1] = p.getY();
 				}
 			}
 		}

--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/ifx/Path2ifx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/ifx/Path2ifx.java
@@ -149,7 +149,7 @@ public class Path2ifx extends AbstractShape2ifx<Path2ifx>
 		assert pt != null : "Point must be not null"; //$NON-NLS-1$
 		if (this.coords != null && !this.coords.isEmpty()) {
 			final int size = this.coords.size();
-			for (int i = 0; i < size; i =+ 2) {
+			for (int i = 0; i < size; i += 2) {
 				final int x = this.coords.get(i);
 				final int y = this.coords.get(i + 1);
 				if (x == pt.ix() && y == pt.iy()) {
@@ -526,7 +526,7 @@ public class Path2ifx extends AbstractShape2ifx<Path2ifx>
 			} else {
 				final Point2D<?, ?> p = new InnerComputationPoint2afp(0, 0);
 				final Iterator<Integer> iterator = this.coords.iterator();
-				for (int i = 0; i < n; i =+ 2) {
+				for (int i = 0; i < n; i += 2) {
 					p.set(iterator.next(), iterator.next());
 					transform.transform(p);
 					clone[i] = (float) p.getX();
@@ -550,7 +550,7 @@ public class Path2ifx extends AbstractShape2ifx<Path2ifx>
 			} else {
 				final Point2D<?, ?> p = new InnerComputationPoint2afp(0, 0);
 				final Iterator<Integer> iterator = this.coords.iterator();
-				for (int i = 0; i < n; i =+ 2) {
+				for (int i = 0; i < n; i += 2) {
 					p.set(iterator.next(), iterator.next());
 					transform.transform(p);
 					clone[i] = p.getX();

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/i/Path2i.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/i/Path2i.java
@@ -192,9 +192,9 @@ public class Path2i extends AbstractShape2i<Path2i>
 		assert pt != null : "Point must be not null"; //$NON-NLS-1$
 		final int px = pt.ix();
 		final int py = pt.iy();
-		for (int i = 0; i < this.numCoords;) {
-			final int x = this.coords[i++];
-			final int y = this.coords[i++];
+		for (int i = 0; i < this.numCoords; i += 2) {
+			final int x = this.coords[i];
+			final int y = this.coords[i + 1];
 			if (x == px && y == py) {
 				return true;
 			}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:ForLoopCounterChangedCheck - “"for" loop stop conditions should be invariant”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:ForLoopCounterChangedCheck
 Please let me know if you have any questions.
Fevzi Ozgul

<!---
@huboard:{"milestone_order":73.0,"order":0.391387939453125,"custom_state":""}
-->
