### PR TITLE
Fixing squid: HiddenFieldCheck Local variables should not shadow class fields

### DIFF
--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/Path2dfx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/Path2dfx.java
@@ -663,9 +663,9 @@ public class Path2dfx extends AbstractShape2dfx<Path2dfx>
 			this.coords.set(idx, y);
 		} else {
 			innerTypesProperty().add(PathElementType.MOVE_TO);
-			final ReadOnlyListWrapper<Double> coords = innerCoordinatesProperty();
-			coords.add(x);
-			coords.add(y);
+			final ReadOnlyListWrapper<Double> coordsLocal = innerCoordinatesProperty();
+			coordsLocal.add(x);
+			coordsLocal.add(y);
 		}
 	}
 
@@ -679,33 +679,33 @@ public class Path2dfx extends AbstractShape2dfx<Path2dfx>
 	public void lineTo(double x, double y) {
 		ensureMoveTo();
 		innerTypesProperty().add(PathElementType.LINE_TO);
-		final ReadOnlyListWrapper<Double> coords = innerCoordinatesProperty();
-		coords.add(x);
-		coords.add(y);
+		final ReadOnlyListWrapper<Double> coordsLocal = innerCoordinatesProperty();
+		coordsLocal.add(x);
+		coordsLocal.add(y);
 	}
 
 	@Override
 	public void quadTo(double x1, double y1, double x2, double y2) {
 		ensureMoveTo();
 		innerTypesProperty().add(PathElementType.QUAD_TO);
-		final ReadOnlyListWrapper<Double> coords = innerCoordinatesProperty();
-		coords.add(x1);
-		coords.add(y1);
-		coords.add(x2);
-		coords.add(y2);
+		final ReadOnlyListWrapper<Double> coordsLocal = innerCoordinatesProperty();
+		coordsLocal.add(x1);
+		coordsLocal.add(y1);
+		coordsLocal.add(x2);
+		coordsLocal.add(y2);
 	}
 
 	@Override
 	public void curveTo(double x1, double y1, double x2, double y2, double x3, double y3) {
 		ensureMoveTo();
 		innerTypesProperty().add(PathElementType.CURVE_TO);
-		final ReadOnlyListWrapper<Double> coords = innerCoordinatesProperty();
-		coords.add(x1);
-		coords.add(y1);
-		coords.add(x2);
-		coords.add(y2);
-		coords.add(x3);
-		coords.add(y3);
+		final ReadOnlyListWrapper<Double> coordsLocal = innerCoordinatesProperty();
+		coordsLocal.add(x1);
+		coordsLocal.add(y1);
+		coordsLocal.add(x2);
+		coordsLocal.add(y2);
+		coordsLocal.add(x3);
+		coordsLocal.add(y3);
 	}
 
 	/** Replies the private coordinates property.

--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/RoundRectangle2dfx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/RoundRectangle2dfx.java
@@ -207,9 +207,9 @@ public class RoundRectangle2dfx extends AbstractRectangularShape2dfx<RoundRectan
 
 	@Override
 	public void setFromCorners(double x1, double y1, double x2, double y2) {
-		final double arcWidth = getArcWidth();
-		final double arcHeight = getArcHeight();
-		setFromCorners(x1, y1, x2, y2, arcWidth, arcHeight);
+		final double arcWidthLocal = getArcWidth();
+		final double arcHeightLocal = getArcHeight();
+		setFromCorners(x1, y1, x2, y2, arcWidthLocal, arcHeightLocal);
 	}
 
 	@Override

--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/UnitVectorProperty.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/UnitVectorProperty.java
@@ -98,11 +98,11 @@ public class UnitVectorProperty extends SimpleObjectProperty<Vector2dfx> {
 		}
 		if (this.fake == null) {
 			this.fake = getGeomFactory().newVector();
-			final DoubleProperty x = new SimpleDoubleProperty(this.fake, "x"); //$NON-NLS-1$
+			final DoubleProperty xLocal = new SimpleDoubleProperty(this.fake, "x"); //$NON-NLS-1$
 			x.bind(internalXProperty());
-			final DoubleProperty y = new SimpleDoubleProperty(this.fake, "y"); //$NON-NLS-1$
+			final DoubleProperty yLocal = new SimpleDoubleProperty(this.fake, "y"); //$NON-NLS-1$
 			y.bind(internalYProperty());
-			this.fake.set(x, y);
+			this.fake.set(xLocal, yLocal);
 		}
 		return this.fake;
 	}

--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/ifx/Path2ifx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/ifx/Path2ifx.java
@@ -677,9 +677,9 @@ public class Path2ifx extends AbstractShape2ifx<Path2ifx>
 			this.coords.set(idx, y);
 		} else {
 			innerTypesProperty().add(PathElementType.MOVE_TO);
-			final ReadOnlyListWrapper<Integer> coords = innerCoordinatesProperty();
-			coords.add(x);
-			coords.add(y);
+			final ReadOnlyListWrapper<Integer> coordsLocal = innerCoordinatesProperty();
+			coordsLocal.add(x);
+			coordsLocal.add(y);
 		}
 	}
 
@@ -693,33 +693,33 @@ public class Path2ifx extends AbstractShape2ifx<Path2ifx>
 	public void lineTo(int x, int y) {
 		ensureMoveTo();
 		innerTypesProperty().add(PathElementType.LINE_TO);
-		final ReadOnlyListWrapper<Integer> coords = innerCoordinatesProperty();
-		coords.add(x);
-		coords.add(y);
+		final ReadOnlyListWrapper<Integer> coordsLocal = innerCoordinatesProperty();
+		coordsLocal.add(x);
+		coordsLocal.add(y);
 	}
 
 	@Override
 	public void quadTo(int x1, int y1, int x2, int y2) {
 		ensureMoveTo();
 		innerTypesProperty().add(PathElementType.QUAD_TO);
-		final ReadOnlyListWrapper<Integer> coords = innerCoordinatesProperty();
-		coords.add(x1);
-		coords.add(y1);
-		coords.add(x2);
-		coords.add(y2);
+		final ReadOnlyListWrapper<Integer> coordsLocal = innerCoordinatesProperty();
+		coordsLocal.add(x1);
+		coordsLocal.add(y1);
+		coordsLocal.add(x2);
+		coordsLocal.add(y2);
 	}
 
 	@Override
 	public void curveTo(int x1, int y1, int x2, int y2, int x3, int y3) {
 		ensureMoveTo();
 		innerTypesProperty().add(PathElementType.CURVE_TO);
-		final ReadOnlyListWrapper<Integer> coords = innerCoordinatesProperty();
-		coords.add(x1);
-		coords.add(y1);
-		coords.add(x2);
-		coords.add(y2);
-		coords.add(x3);
-		coords.add(y3);
+		final ReadOnlyListWrapper<Integer> coordsLocal = innerCoordinatesProperty();
+		coordsLocal.add(x1);
+		coordsLocal.add(y1);
+		coordsLocal.add(x2);
+		coordsLocal.add(y2);
+		coordsLocal.add(x3);
+		coordsLocal.add(y3);
 	}
 
 	/** Replies the private coordinates property.

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/afp/RoundRectangle2afp.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/afp/RoundRectangle2afp.java
@@ -1083,8 +1083,8 @@ public interface RoundRectangle2afp<
 						this.lastX, this.lastY);
 			}
 
-			final double x = this.lastX;
-			final double y = this.lastY;
+			final double xLocal = this.lastX;
+			final double yLocal = this.lastY;
 
 			final double curveX;
 			final double curveY;
@@ -1093,66 +1093,66 @@ public interface RoundRectangle2afp<
 			case 0:
 				this.lastX = this.x + this.width - this.arcWidth;
 				return getGeomFactory().newLinePathElement(
-						x, y,
+						xLocal, yLocal,
 						this.lastX, this.lastY);
 			case 1:
 				this.lastX += this.arcWidth;
 				this.lastY += this.arcHeight;
-				curveX = x + AbstractCirclePathIterator.CTRL_POINT_DISTANCE * this.arcWidth;
+				curveX = xLocal + AbstractCirclePathIterator.CTRL_POINT_DISTANCE * this.arcWidth;
 				curveY = this.lastY - AbstractCirclePathIterator.CTRL_POINT_DISTANCE * this.arcHeight;
 				return getGeomFactory().newCurvePathElement(
-						x, y,
-						curveX, y,
+						xLocal, yLocal,
+						curveX, yLocal,
 						this.lastX, curveY,
 						this.lastX, this.lastY);
 			case 2:
 				this.lastY = this.y + this.height - this.arcHeight;
 				return getGeomFactory().newLinePathElement(
-						x, y,
+						xLocal, yLocal,
 						this.lastX, this.lastY);
 			case 3:
 				this.lastX -= this.arcWidth;
 				this.lastY += this.arcHeight;
 				curveX = this.lastX + AbstractCirclePathIterator.CTRL_POINT_DISTANCE * this.arcWidth;
-				curveY = y + AbstractCirclePathIterator.CTRL_POINT_DISTANCE * this.arcHeight;
+				curveY = yLocal + AbstractCirclePathIterator.CTRL_POINT_DISTANCE * this.arcHeight;
 				return getGeomFactory().newCurvePathElement(
-						x, y,
-						x, curveY,
+						xLocal, yLocal,
+						xLocal, curveY,
 						curveX, this.lastY,
 						this.lastX, this.lastY);
 			case 4:
 				this.lastX = this.x + this.arcWidth;
 				return getGeomFactory().newLinePathElement(
-						x, y,
+						xLocal, yLocal,
 						this.lastX, this.lastY);
 			case 5:
 				this.lastX -= this.arcWidth;
 				this.lastY -= this.arcHeight;
-				curveX = x - AbstractCirclePathIterator.CTRL_POINT_DISTANCE * this.arcWidth;
+				curveX = xLocal - AbstractCirclePathIterator.CTRL_POINT_DISTANCE * this.arcWidth;
 				curveY = this.lastY + AbstractCirclePathIterator.CTRL_POINT_DISTANCE * this.arcHeight;
 				return getGeomFactory().newCurvePathElement(
-						x, y,
-						curveX, y,
+						xLocal, yLocal,
+						curveX, yLocal,
 						this.lastX, curveY,
 						this.lastX, this.lastY);
 			case 6:
 				this.lastY = this.y + this.arcHeight;
 				return getGeomFactory().newLinePathElement(
-						x, y,
+						xLocal, yLocal,
 						this.lastX, this.lastY);
 			case 7:
 				this.lastX += this.arcWidth;
 				this.lastY -= this.arcHeight;
 				curveX = this.lastX - AbstractCirclePathIterator.CTRL_POINT_DISTANCE * this.arcWidth;
-				curveY = y - AbstractCirclePathIterator.CTRL_POINT_DISTANCE * this.arcHeight;
+				curveY = yLocal - AbstractCirclePathIterator.CTRL_POINT_DISTANCE * this.arcHeight;
 				return getGeomFactory().newCurvePathElement(
-						x, y,
-						x, curveY,
+						xLocal, yLocal,
+						xLocal, curveY,
 						curveX, this.lastY,
 						this.lastX, this.lastY);
 			default:
 				return getGeomFactory().newClosePathElement(
-						x, y,
+						xLocal, yLocal,
 						this.moveX, this.moveY);
 			}
 		}
@@ -1246,8 +1246,8 @@ public interface RoundRectangle2afp<
 						this.last.getX(), this.last.getY());
 			}
 
-			final double x = this.last.getX();
-			final double y = this.last.getY();
+			final double xLocal = this.last.getX();
+			final double yLocal = this.last.getY();
 
 			switch (idx) {
 			case 0:
@@ -1256,7 +1256,7 @@ public interface RoundRectangle2afp<
 						this.y);
 				this.transform.transform(this.last);
 				return getGeomFactory().newLinePathElement(
-						x, y,
+						xLocal, yLocal,
 						this.last.getX(), this.last.getY());
 			case 1:
 				this.last.set(
@@ -1272,7 +1272,7 @@ public interface RoundRectangle2afp<
 				this.transform.transform(this.controlPoint1);
 				this.transform.transform(this.controlPoint2);
 				return getGeomFactory().newCurvePathElement(
-						x, y,
+						xLocal, yLocal,
 						this.controlPoint1.getX(), this.controlPoint1.getY(),
 						this.controlPoint2.getX(), this.controlPoint2.getY(),
 						this.last.getX(), this.last.getY());
@@ -1282,7 +1282,7 @@ public interface RoundRectangle2afp<
 						this.y + this.height - this.arcHeight);
 				this.transform.transform(this.last);
 				return getGeomFactory().newLinePathElement(
-						x, y,
+						xLocal, yLocal,
 						this.last.getX(), this.last.getY());
 			case 3:
 				this.last.set(
@@ -1298,7 +1298,7 @@ public interface RoundRectangle2afp<
 				this.transform.transform(this.controlPoint1);
 				this.transform.transform(this.controlPoint2);
 				return getGeomFactory().newCurvePathElement(
-						x, y,
+						xLocal, yLocal,
 						this.controlPoint1.getX(), this.controlPoint1.getY(),
 						this.controlPoint2.getX(), this.controlPoint2.getY(),
 						this.last.getX(), this.last.getY());
@@ -1308,7 +1308,7 @@ public interface RoundRectangle2afp<
 						this.y + this.height);
 				this.transform.transform(this.last);
 				return getGeomFactory().newLinePathElement(
-						x, y,
+						xLocal, yLocal,
 						this.last.getX(), this.last.getY());
 			case 5:
 				this.last.set(
@@ -1324,7 +1324,7 @@ public interface RoundRectangle2afp<
 				this.transform.transform(this.controlPoint1);
 				this.transform.transform(this.controlPoint2);
 				return getGeomFactory().newCurvePathElement(
-						x, y,
+						xLocal, yLocal,
 						this.controlPoint1.getX(), this.controlPoint1.getY(),
 						this.controlPoint2.getX(), this.controlPoint2.getY(),
 						this.last.getX(), this.last.getY());
@@ -1334,7 +1334,7 @@ public interface RoundRectangle2afp<
 						this.y + this.arcHeight);
 				this.transform.transform(this.last);
 				return getGeomFactory().newLinePathElement(
-						x, y,
+						xLocal, yLocal,
 						this.last.getX(), this.last.getY());
 			case 7:
 				this.controlPoint1.set(
@@ -1346,13 +1346,13 @@ public interface RoundRectangle2afp<
 				this.transform.transform(this.controlPoint1);
 				this.transform.transform(this.controlPoint2);
 				return getGeomFactory().newCurvePathElement(
-						x, y,
+						xLocal, yLocal,
 						this.controlPoint1.getX(), this.controlPoint1.getY(),
 						this.controlPoint2.getX(), this.controlPoint2.getY(),
 						this.move.getX(), this.move.getY());
 			default:
 				return getGeomFactory().newClosePathElement(
-						x, y,
+						xLocal, yLocal,
 						this.move.getX(), this.move.getY());
 			}
 		}


### PR DESCRIPTION
  This pull request is focused on resolving occurrences of Sonar rule 
 squid:HiddenFieldCheck - “Local variables should not shadow class fields”. 
 You can find more information about the issues here: 
 https://dev.eclipse.org/sonar/rules/show/squid:HiddenFieldCheck
 Please let me know if you have any questions.
 Fevzi Ozgul