### PR TITLE
Fixing squid: S2184 Math operands should be cast before assignment

### DIFF
--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/ai/PathShadow2ai.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/ai/PathShadow2ai.java
@@ -306,7 +306,7 @@ public class PathShadow2ai<B extends Rectangle2ai<?, ?, ?, ?, ?, B>> {
 		if (sx0 > shadowXmax && sx1 > shadowXmax) {
 			// The line is entirely at the right of the shadow
 			if (sy1 != sy0) {
-				final double alpha = (sx1 - sx0) / (sy1 - sy0);
+				final double alpha = (double) (sx1 - sx0) / (sy1 - sy0);
 				if (sy0 < sy1) {
 					if (sy0 <= shadowYmin) {
 						final int xintercept = (int) Math.round(sx0 + (shadowYmin - sy0) * alpha);

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/ai/Rectangle2ai.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/ai/Rectangle2ai.java
@@ -375,7 +375,7 @@ public interface Rectangle2ai<
 		} else {
 			dy = 0;
 		}
-		return dx * dx + (double) dy * dy;
+		return (double) (dx * dx + dy * dy);
 	}
 
 	@Pure
@@ -398,7 +398,7 @@ public interface Rectangle2ai<
 		} else {
 			dy = 0;
 		}
-		return dx + (double) dy;
+		return (double) (dx + dy);
 	}
 
 	@Pure

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/ai/Rectangle2ai.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/ai/Rectangle2ai.java
@@ -375,7 +375,7 @@ public interface Rectangle2ai<
 		} else {
 			dy = 0;
 		}
-		return dx * dx + dy * dy;
+		return dx * dx + (double) dy * dy;
 	}
 
 	@Pure
@@ -398,7 +398,7 @@ public interface Rectangle2ai<
 		} else {
 			dy = 0;
 		}
-		return dx + dy;
+		return dx + (double) dy;
 	}
 
 	@Pure

--- a/core/util/src/main/java/org/arakhne/afc/progress/DefaultProgression.java
+++ b/core/util/src/main/java/org/arakhne/afc/progress/DefaultProgression.java
@@ -200,7 +200,7 @@ public class DefaultProgression implements Progression {
 	@Override
 	@SuppressWarnings("checkstyle:magicnumber")
 	public double getPercent() {
-		final double extent = this.max - this.min;
+		final double extent = this.max - (double) this.min;
 		if (extent == 0.) {
 			return 0.;
 		}
@@ -209,7 +209,7 @@ public class DefaultProgression implements Progression {
 
 	@Override
 	public double getProgressionFactor() {
-		final double extent = this.max - this.min;
+		final double extent = this.max - (double) this.min;
 		if (extent == 0.) {
 			return 0.;
 		}

--- a/core/util/src/main/java/org/arakhne/afc/progress/DefaultProgression.java
+++ b/core/util/src/main/java/org/arakhne/afc/progress/DefaultProgression.java
@@ -200,7 +200,7 @@ public class DefaultProgression implements Progression {
 	@Override
 	@SuppressWarnings("checkstyle:magicnumber")
 	public double getPercent() {
-		final double extent = this.max - (double) this.min;
+		final int extent = this.max - this.min;
 		if (extent == 0.) {
 			return 0.;
 		}
@@ -209,7 +209,7 @@ public class DefaultProgression implements Progression {
 
 	@Override
 	public double getProgressionFactor() {
-		final double extent = this.max - (double) this.min;
+		final int extent = this.max - this.min;
 		if (extent == 0.) {
 			return 0.;
 		}


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S2184 - “Math operands should be cast before assignment”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S2184
 Please let me know if you have any questions.
Fevzi Ozgul

<!---
@huboard:{"order":0.40130615234375,"milestone_order":80,"custom_state":""}
-->
