### PR TITLE
Fixing squid: S1141 Try-catch blocks should not be nested Part 1

### DIFF
--- a/advanced/attributes/src/main/java/org/arakhne/afc/attrs/collection/BufferedAttributeCollection.java
+++ b/advanced/attributes/src/main/java/org/arakhne/afc/attrs/collection/BufferedAttributeCollection.java
@@ -472,35 +472,29 @@ public abstract class BufferedAttributeCollection extends AbstractAttributeColle
 		return false;
 	}
 
+    private   AttributeValue getValueForName(String name) {
+		final AttributeValue valueForName = null;
+		try {
+			return  extractValueFor(name);
+		} catch (AttributeException exception) {
+			//
+		}
+		return valueForName;
+	}
+
 	@Override
 	public boolean renameAttribute(String oldname, String newname, boolean overwrite) {
 		try {
-			AttributeValue valueForOldName = null;
-
-			try {
-				valueForOldName = extractValueFor(oldname);
-			} catch (AttributeException exception) {
-				//
-			}
-
+			final AttributeValue valueForOldName = getValueForName(oldname);
 			// The source attribute does not exist.
 			if (valueForOldName == null) {
 				return false;
 			}
-
-			AttributeValue oldValueForNewName = null;
-
-			try {
-				oldValueForNewName = extractValueFor(newname);
-			} catch (AttributeException exception) {
-				//
-			}
-
+			final AttributeValue oldValueForNewName = getValueForName(newname);
 			// Target attribute is existing and overwrite was disabled.
 			if ((!overwrite) && (oldValueForNewName != null)) {
 				return false;
 			}
-
 			final AttributeValue oldValueCopyForNewName = new AttributeValueImpl(oldValueForNewName);
 
 			removeValue(oldname);

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/d/AbstractShape2d.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/d/AbstractShape2d.java
@@ -100,15 +100,19 @@ public abstract class AbstractShape2d<T extends AbstractShape2d<?>> implements S
 			return true;
 		}
 		try {
-			try {
-				return equalsToShape((T) obj);
-			} catch (ClassCastException exception) {
-				return equalsToPathIterator((PathIterator2D<?>) obj);
-			}
+			return isEqualsToShape(obj);
 		} catch (Throwable exception) {
 			//
 		}
 		return false;
+	}
+
+	private boolean isEqualsToShape(Object obj) {
+		try {
+			return equalsToShape((T) obj);
+		} catch (ClassCastException exception) {
+			return equalsToPathIterator((PathIterator2D<?>) obj);
+		}
 	}
 
 	@Pure

--- a/core/math/src/test/java/org/arakhne/afc/math/geometry/d2/ai/AbstractCircle2aiTest.java
+++ b/core/math/src/test/java/org/arakhne/afc/math/geometry/d2/ai/AbstractCircle2aiTest.java
@@ -28,12 +28,16 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.Iterator;
 
+import org.junit.Test;
+
 import org.arakhne.afc.math.MathConstants;
 import org.arakhne.afc.math.geometry.PathElementType;
 import org.arakhne.afc.math.geometry.d2.Point2D;
 import org.arakhne.afc.math.geometry.d2.Shape2D;
 import org.arakhne.afc.math.geometry.d2.Transform2D;
-import org.junit.Test;
+
+
+
 
 @SuppressWarnings("all")
 public abstract class AbstractCircle2aiTest<T extends Circle2ai<?, T, ?, ?, ?, B>,

--- a/core/math/src/test/java/org/arakhne/afc/math/geometry/d2/ai/AbstractPath2aiTest.java
+++ b/core/math/src/test/java/org/arakhne/afc/math/geometry/d2/ai/AbstractPath2aiTest.java
@@ -1,3 +1,4 @@
+
 /*
  * $Id$
  * This file is a part of the Arakhne Foundation Classes, http://www.arakhne.org/afc

--- a/core/math/src/test/java/org/arakhne/afc/math/geometry/d2/ai/AbstractSegment2aiTest.java
+++ b/core/math/src/test/java/org/arakhne/afc/math/geometry/d2/ai/AbstractSegment2aiTest.java
@@ -29,12 +29,15 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.Iterator;
 
+import org.junit.Test;
+
 import org.arakhne.afc.math.MathConstants;
 import org.arakhne.afc.math.geometry.PathElementType;
 import org.arakhne.afc.math.geometry.d2.Point2D;
 import org.arakhne.afc.math.geometry.d2.Shape2D;
 import org.arakhne.afc.math.geometry.d2.Transform2D;
-import org.junit.Test;
+
+
 
 @SuppressWarnings("all")
 public abstract class AbstractSegment2aiTest<T extends Segment2ai<?, T, ?, ?, ?, B>,


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1141 - Try-catch blocks should not be nested ”. 
This PR will remove 60min TD.
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1141
 Please let me know if you have any questions.
 Fevzi Ozgul