### PR TITLE
Fixing squid: S1948 Fields in a "Serializable" class should either be transient or serializable

### DIFF
--- a/core/math/src/main/java/org/arakhne/afc/math/tree/node/AbstractParentlessTreeNode.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/tree/node/AbstractParentlessTreeNode.java
@@ -76,7 +76,7 @@ public abstract class AbstractParentlessTreeNode<D, N extends AbstractParentless
 
 	/** Associated user data.
 	 */
-	private List<D> data;
+	private transient List<D> data;
 
 	/** Indicates if a linked list must be used to store the data.
 	 * If <code>false</code>, an ArrayList will be used.
@@ -576,7 +576,7 @@ public abstract class AbstractParentlessTreeNode<D, N extends AbstractParentless
 
 		private static final long serialVersionUID = -8019401625554108057L;
 
-		private final List<D> backgroundList;
+		private final transient List<D> backgroundList;
 
 		/** Construct collection.
 		 * @param list the original list.

--- a/core/util/src/main/java/org/arakhne/afc/util/Quadruplet.java
+++ b/core/util/src/main/java/org/arakhne/afc/util/Quadruplet.java
@@ -40,13 +40,13 @@ public class Quadruplet<A, B, C, D> implements Serializable {
 
 	private static final long serialVersionUID = -1357391439043190025L;
 
-	private A avalue;
+	private transient A avalue;
 
-	private B bvalue;
+	private transient B bvalue;
 
-	private C cvalue;
+	private transient C cvalue;
 
-	private D dvalue;
+	private transient D dvalue;
 
 	/** Construct the quadruplet.
 	 */


### PR DESCRIPTION
  This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1948 - “S Fields in a "Serializable" class should either be transient or serializable”. 
This PR will remove 180 min TD.
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1948
 Please let me know if you have any questions.
Fevzi Ozgul