### PR TITLE
Fixing squid: S00100 Method names should comply with a naming convention Part 1

### DIFF
--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/Shape2D.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/Shape2D.java
@@ -314,7 +314,7 @@ public interface Shape2D<
      * @param v the vector
      * @see #translate(Vector2D)
      */
-    default void operator_add(Vector2D<?, ?> v) {
+    default void operatorAdd(Vector2D<?, ?> v) {
         translate(v);
     }
 
@@ -329,7 +329,7 @@ public interface Shape2D<
      * @see #translate(Vector2D)
      */
     @Pure
-    default IT operator_plus(Vector2D<?, ?> v) {
+    default IT operatorPlus(Vector2D<?, ?> v) {
         final IT clone = clone();
         clone.translate(v);
         return clone;
@@ -344,7 +344,7 @@ public interface Shape2D<
      * @param v the vector
      * @see #translate(Vector2D)
      */
-    default void operator_remove(Vector2D<?, ?> v) {
+    default void operatorRemove(Vector2D<?, ?> v) {
         final Vector2D<?, ?> negate = getGeomFactory().newVector();
         negate.negate(v);
         translate(negate);
@@ -361,7 +361,7 @@ public interface Shape2D<
      * @see #translate(Vector2D)
      */
     @Pure
-    default IT operator_minus(Vector2D<?, ?> v) {
+    default IT operatorMinus(Vector2D<?, ?> v) {
         final IT clone = clone();
         final Vector2D<?, ?> negate = getGeomFactory().newVector();
         negate.negate(v);
@@ -380,7 +380,7 @@ public interface Shape2D<
      * @see #createTransformedShape(Transform2D)
      */
     @Pure
-    default ST operator_multiply(Transform2D t) {
+    default ST operatorMultiply(Transform2D t) {
         return createTransformedShape(t);
     }
 
@@ -395,7 +395,7 @@ public interface Shape2D<
      * @see #createTransformedShape(Transform2D)
      */
     @Pure
-    default boolean operator_and(Point2D<?, ?> point) {
+    default boolean operatorAnd(Point2D<?, ?> point) {
         return contains(point);
     }
 
@@ -415,7 +415,7 @@ public interface Shape2D<
      */
     @Pure
     @Unefficient
-    default boolean operator_and(Shape2D<?, ?, ?, ?, ?, ?> shape) {
+    default boolean operatorAnd(Shape2D<?, ?, ?, ?, ?, ?> shape) {
         return intersects(shape);
     }
 
@@ -430,7 +430,7 @@ public interface Shape2D<
      * @see #getDistance(Point2D)
      */
     @Pure
-    default double operator_upTo(Point2D<?, ?> pt) {
+    default double operatorUpTo(Point2D<?, ?> pt) {
         return getDistance(pt);
     }
 

--- a/core/math/src/test/java/org/arakhne/afc/math/geometry/d2/afp/AbstractCircle2afpTest.java
+++ b/core/math/src/test/java/org/arakhne/afc/math/geometry/d2/afp/AbstractCircle2afpTest.java
@@ -979,7 +979,7 @@ public abstract class AbstractCircle2afpTest<T extends Circle2afp<?, T, ?, ?, ?,
 
 	@Override
 	public void operator_addVector2D() {
-		this.shape.operator_add(createVector(123.456, -789.123));
+		this.shape.operatorAdd(createVector(123.456, -789.123));
 		assertEpsilonEquals(128.456, this.shape.getX());
 		assertEpsilonEquals(-781.123, this.shape.getY());
 		assertEpsilonEquals(5, this.shape.getRadius());
@@ -987,7 +987,7 @@ public abstract class AbstractCircle2afpTest<T extends Circle2afp<?, T, ?, ?, ?,
 
 	@Override
 	public void operator_plusVector2D() {
-		T shape = this.shape.operator_plus(createVector(123.456, -789.123));
+		T shape = this.shape.operatorPlus(createVector(123.456, -789.123));
 		assertEpsilonEquals(128.456, shape.getX());
 		assertEpsilonEquals(-781.123, shape.getY());
 		assertEpsilonEquals(5, shape.getRadius());
@@ -995,7 +995,7 @@ public abstract class AbstractCircle2afpTest<T extends Circle2afp<?, T, ?, ?, ?,
 
 	@Override
 	public void operator_removeVector2D() {
-		this.shape.operator_remove(createVector(123.456, -789.123));
+		this.shape.operatorRemove(createVector(123.456, -789.123));
 		assertEpsilonEquals(-118.456, this.shape.getX());
 		assertEpsilonEquals(797.123, this.shape.getY());
 		assertEpsilonEquals(5, this.shape.getRadius());
@@ -1003,7 +1003,7 @@ public abstract class AbstractCircle2afpTest<T extends Circle2afp<?, T, ?, ?, ?,
 
 	@Override
 	public void operator_minusVector2D() {
-		T shape = this.shape.operator_minus(createVector(123.456, -789.123));
+		T shape = this.shape.operatorMinus(createVector(123.456, -789.123));
 		assertEpsilonEquals(-118.456, shape.getX());
 		assertEpsilonEquals(797.123, shape.getY());
 		assertEpsilonEquals(5, shape.getRadius());
@@ -1014,20 +1014,20 @@ public abstract class AbstractCircle2afpTest<T extends Circle2afp<?, T, ?, ?, ?,
 		Transform2D tr;
 		Shape2afp newShape;
 		
-		newShape = this.shape.operator_multiply(null);
+		newShape = this.shape.operatorMultiply(null);
 		assertNotNull(newShape);
 		assertNotSame(this.shape, newShape);
 		assertEquals(this.shape, newShape);
 
 		tr = new Transform2D();
-		newShape = this.shape.operator_multiply(tr);
+		newShape = this.shape.operatorMultiply(tr);
 		assertNotNull(newShape);
 		assertNotSame(this.shape, newShape);
 		assertEquals(this.shape, newShape);
 
 		tr = new Transform2D();
 		tr.makeTranslationMatrix(10, -10);
-		newShape = this.shape.operator_multiply(tr);
+		newShape = this.shape.operatorMultiply(tr);
 		assertNotNull(newShape);
 		assertNotSame(this.shape, newShape);
 		assertTrue(newShape instanceof Path2afp);
@@ -1043,29 +1043,29 @@ public abstract class AbstractCircle2afpTest<T extends Circle2afp<?, T, ?, ?, ?,
 
 	@Override
 	public void operator_andPoint2D() {
-		assertFalse(this.shape.operator_and(createPoint(0,0)));
-		assertFalse(this.shape.operator_and(createPoint(11,10)));
-		assertFalse(this.shape.operator_and(createPoint(11,50)));
-		assertFalse(this.shape.operator_and(createPoint(9,12)));
-		assertTrue(this.shape.operator_and(createPoint(9,11)));
-		assertTrue(this.shape.operator_and(createPoint(8,12)));
-		assertTrue(this.shape.operator_and(createPoint(3,7)));
-		assertFalse(this.shape.operator_and(createPoint(10,11)));
-		assertTrue(this.shape.operator_and(createPoint(9,10)));
+		assertFalse(this.shape.operatorAnd(createPoint(0,0)));
+		assertFalse(this.shape.operatorAnd(createPoint(11,10)));
+		assertFalse(this.shape.operatorAnd(createPoint(11,50)));
+		assertFalse(this.shape.operatorAnd(createPoint(9,12)));
+		assertTrue(this.shape.operatorAnd(createPoint(9,11)));
+		assertTrue(this.shape.operatorAnd(createPoint(8,12)));
+		assertTrue(this.shape.operatorAnd(createPoint(3,7)));
+		assertFalse(this.shape.operatorAnd(createPoint(10,11)));
+		assertTrue(this.shape.operatorAnd(createPoint(9,10)));
 	}
 
 	@Override
 	public void operator_andShape2D() {
-		assertTrue(this.shape.operator_and(createCircle(10, 10, 1)));
-		assertTrue(this.shape.operator_and(createEllipse(9, 9, 2, 2)));
+		assertTrue(this.shape.operatorAnd(createCircle(10, 10, 1)));
+		assertTrue(this.shape.operatorAnd(createEllipse(9, 9, 2, 2)));
 	}
 
 	@Override
 	public void operator_upToPoint2D() {
-		assertEpsilonEquals(3.74643, this.shape.operator_upTo(createPoint(.5,.5)));
-		assertEpsilonEquals(7.9769, this.shape.operator_upTo(createPoint(-1.2,-3.4)));
-		assertEpsilonEquals(1.6483, this.shape.operator_upTo(createPoint(-1.2,5.6)));
-		assertEpsilonEquals(0, this.shape.operator_upTo(createPoint(7.6,5.6)));
+		assertEpsilonEquals(3.74643, this.shape.operatorUpTo(createPoint(.5,.5)));
+		assertEpsilonEquals(7.9769, this.shape.operatorUpTo(createPoint(-1.2,-3.4)));
+		assertEpsilonEquals(1.6483, this.shape.operatorUpTo(createPoint(-1.2,5.6)));
+		assertEpsilonEquals(0, this.shape.operatorUpTo(createPoint(7.6,5.6)));
 	}
 
 	@Test

--- a/core/math/src/test/java/org/arakhne/afc/math/geometry/d2/afp/AbstractEllipse2afpTest.java
+++ b/core/math/src/test/java/org/arakhne/afc/math/geometry/d2/afp/AbstractEllipse2afpTest.java
@@ -1640,7 +1640,7 @@ public abstract class AbstractEllipse2afpTest<T extends Ellipse2afp<?, T, ?, ?, 
 
 	@Override
 	public void operator_addVector2D() {
-		this.shape.operator_add(createVector(123.456, -789.123));
+		this.shape.operatorAdd(createVector(123.456, -789.123));
 		assertEpsilonEquals(128.456, this.shape.getMinX());
 		assertEpsilonEquals(-781.123, this.shape.getMinY());
 		assertEpsilonEquals(133.456, this.shape.getMaxX());
@@ -1649,7 +1649,7 @@ public abstract class AbstractEllipse2afpTest<T extends Ellipse2afp<?, T, ?, ?, 
 
 	@Override
 	public void operator_plusVector2D() {
-		T shape = this.shape.operator_plus(createVector(123.456, -789.123));
+		T shape = this.shape.operatorPlus(createVector(123.456, -789.123));
 		assertEpsilonEquals(128.456, shape.getMinX());
 		assertEpsilonEquals(-781.123, shape.getMinY());
 		assertEpsilonEquals(133.456, shape.getMaxX());
@@ -1658,7 +1658,7 @@ public abstract class AbstractEllipse2afpTest<T extends Ellipse2afp<?, T, ?, ?, 
 
 	@Override
 	public void operator_removeVector2D() {
-		this.shape.operator_remove(createVector(123.456, -789.123));
+		this.shape.operatorRemove(createVector(123.456, -789.123));
 		assertEpsilonEquals(-118.456, this.shape.getMinX());
 		assertEpsilonEquals(797.123, this.shape.getMinY());
 		assertEpsilonEquals(-113.456, this.shape.getMaxX());
@@ -1667,7 +1667,7 @@ public abstract class AbstractEllipse2afpTest<T extends Ellipse2afp<?, T, ?, ?, 
 
 	@Override
 	public void operator_minusVector2D() {
-		T shape = this.shape.operator_minus(createVector(123.456, -789.123));
+		T shape = this.shape.operatorMinus(createVector(123.456, -789.123));
 		assertEpsilonEquals(-118.456, shape.getMinX());
 		assertEpsilonEquals(797.123, shape.getMinY());
 		assertEpsilonEquals(-113.456, shape.getMaxX());
@@ -1679,20 +1679,20 @@ public abstract class AbstractEllipse2afpTest<T extends Ellipse2afp<?, T, ?, ?, 
 		Transform2D tr;
 		Shape2afp newShape;
 		
-		newShape = this.shape.operator_multiply(null);
+		newShape = this.shape.operatorMultiply(null);
 		assertNotNull(newShape);
 		assertNotSame(this.shape, newShape);
 		assertEquals(this.shape, newShape);
 
 		tr = new Transform2D();
-		newShape = this.shape.operator_multiply(tr);
+		newShape = this.shape.operatorMultiply(tr);
 		assertNotNull(newShape);
 		assertNotSame(this.shape, newShape);
 		assertEquals(this.shape, newShape);
 
 		tr = new Transform2D();
 		tr.makeTranslationMatrix(10, -10);
-		newShape = this.shape.operator_multiply(tr);
+		newShape = this.shape.operatorMultiply(tr);
 		assertNotNull(newShape);
 		assertNotSame(this.shape, newShape);
 		assertTrue(newShape instanceof Path2afp);
@@ -1708,36 +1708,36 @@ public abstract class AbstractEllipse2afpTest<T extends Ellipse2afp<?, T, ?, ?, 
 
 	@Override
 	public void operator_andPoint2D() {
-		assertFalse(this.shape.operator_and(createPoint(0,0)));
-		assertFalse(this.shape.operator_and(createPoint(11,10)));
-		assertFalse(this.shape.operator_and(createPoint(11,50)));
-		assertTrue(this.shape.operator_and(createPoint(9,12)));
-		assertTrue(this.shape.operator_and(createPoint(9,11)));
-		assertTrue(this.shape.operator_and(createPoint(8,12)));
-		assertFalse(this.shape.operator_and(createPoint(3,7)));
-		assertFalse(this.shape.operator_and(createPoint(10,12)));
-		assertFalse(this.shape.operator_and(createPoint(10,11)));
-		assertTrue(this.shape.operator_and(createPoint(9,10)));
-		assertFalse(this.shape.operator_and(createPoint(9.5,9.5)));
+		assertFalse(this.shape.operatorAnd(createPoint(0,0)));
+		assertFalse(this.shape.operatorAnd(createPoint(11,10)));
+		assertFalse(this.shape.operatorAnd(createPoint(11,50)));
+		assertTrue(this.shape.operatorAnd(createPoint(9,12)));
+		assertTrue(this.shape.operatorAnd(createPoint(9,11)));
+		assertTrue(this.shape.operatorAnd(createPoint(8,12)));
+		assertFalse(this.shape.operatorAnd(createPoint(3,7)));
+		assertFalse(this.shape.operatorAnd(createPoint(10,12)));
+		assertFalse(this.shape.operatorAnd(createPoint(10,11)));
+		assertTrue(this.shape.operatorAnd(createPoint(9,10)));
+		assertFalse(this.shape.operatorAnd(createPoint(9.5,9.5)));
 	}
 
 	@Override
 	public void operator_andShape2D() {
-		assertTrue(this.shape.operator_and(createCircle(7.5, 7, 2)));
-		assertTrue(this.shape.operator_and(createEllipse(0.1, 8, 5, 10)));
+		assertTrue(this.shape.operatorAnd(createCircle(7.5, 7, 2)));
+		assertTrue(this.shape.operatorAnd(createEllipse(0.1, 8, 5, 10)));
 	}
 
 	@Override
 	public void operator_upToPoint2D() {
-		assertEpsilonEquals(10.63171, this.shape.operator_upTo(createPoint(0, 0)));
-		assertEpsilonEquals(9.12909, this.shape.operator_upTo(createPoint(0, 24)));
-		assertEpsilonEquals(17.48928, this.shape.operator_upTo(createPoint(24, 0)));
-		assertEpsilonEquals(16.5153, this.shape.operator_upTo(createPoint(24, 24)));
-		assertEpsilonEquals(8, this.shape.operator_upTo(createPoint(18, 13)));
-		assertEpsilonEquals(5, this.shape.operator_upTo(createPoint(0, 13)));
-		assertEpsilonEquals(6, this.shape.operator_upTo(createPoint(7.5, 24)));
-		assertEpsilonEquals(8, this.shape.operator_upTo(createPoint(7.5, 0)));
-		assertEpsilonEquals(0, this.shape.operator_upTo(createPoint(6, 11)));
+		assertEpsilonEquals(10.63171, this.shape.operatorUpTo(createPoint(0, 0)));
+		assertEpsilonEquals(9.12909, this.shape.operatorUpTo(createPoint(0, 24)));
+		assertEpsilonEquals(17.48928, this.shape.operatorUpTo(createPoint(24, 0)));
+		assertEpsilonEquals(16.5153, this.shape.operatorUpTo(createPoint(24, 24)));
+		assertEpsilonEquals(8, this.shape.operatorUpTo(createPoint(18, 13)));
+		assertEpsilonEquals(5, this.shape.operatorUpTo(createPoint(0, 13)));
+		assertEpsilonEquals(6, this.shape.operatorUpTo(createPoint(7.5, 24)));
+		assertEpsilonEquals(8, this.shape.operatorUpTo(createPoint(7.5, 0)));
+		assertEpsilonEquals(0, this.shape.operatorUpTo(createPoint(6, 11)));
 	}
 
 	@Test

--- a/core/math/src/test/java/org/arakhne/afc/math/geometry/d2/afp/AbstractMultiShape2afpTest.java
+++ b/core/math/src/test/java/org/arakhne/afc/math/geometry/d2/afp/AbstractMultiShape2afpTest.java
@@ -705,7 +705,7 @@ public abstract class AbstractMultiShape2afpTest<T extends MultiShape2afp<?, T, 
 
 	@Override
 	public void operator_addVector2D() {
-		this.shape.operator_add(createVector(10, -2));
+		this.shape.operatorAdd(createVector(10, -2));
 		PathIterator2afp pi = this.shape.getPathIterator();
 		assertElement(pi, PathElementType.MOVE_TO, 15, 6);
 		assertElement(pi, PathElementType.LINE_TO, 17, 6);
@@ -723,7 +723,7 @@ public abstract class AbstractMultiShape2afpTest<T extends MultiShape2afp<?, T, 
 
 	@Override
 	public void operator_plusVector2D() {
-		T shape = this.shape.operator_plus(createVector(10, -2));
+		T shape = this.shape.operatorPlus(createVector(10, -2));
 		PathIterator2afp pi = shape.getPathIterator();
 		assertElement(pi, PathElementType.MOVE_TO, 15, 6);
 		assertElement(pi, PathElementType.LINE_TO, 17, 6);
@@ -741,7 +741,7 @@ public abstract class AbstractMultiShape2afpTest<T extends MultiShape2afp<?, T, 
 
 	@Override
 	public void operator_removeVector2D() {
-		this.shape.operator_remove(createVector(10, -2));
+		this.shape.operatorRemove(createVector(10, -2));
 		PathIterator2afp pi = this.shape.getPathIterator();
 		assertElement(pi, PathElementType.MOVE_TO, -5, 10);
 		assertElement(pi, PathElementType.LINE_TO, -3, 10);
@@ -759,7 +759,7 @@ public abstract class AbstractMultiShape2afpTest<T extends MultiShape2afp<?, T, 
 
 	@Override
 	public void operator_minusVector2D() {
-		T shape = this.shape.operator_minus(createVector(10, -2));
+		T shape = this.shape.operatorMinus(createVector(10, -2));
 		PathIterator2afp pi = shape.getPathIterator();
 		assertElement(pi, PathElementType.MOVE_TO, -5, 10);
 		assertElement(pi, PathElementType.LINE_TO, -3, 10);
@@ -779,7 +779,7 @@ public abstract class AbstractMultiShape2afpTest<T extends MultiShape2afp<?, T, 
 	public void operator_multiplyTransform2D() {
 		Transform2D transform = new Transform2D();
 		transform.setTranslation(10, -2);
-		Shape2afp newShape = this.shape.operator_multiply(transform);
+		Shape2afp newShape = this.shape.operatorMultiply(transform);
 		PathIterator2afp pi = (PathIterator2afp) newShape.getPathIterator();
 		assertElement(pi, PathElementType.MOVE_TO, 15, 6);
 		assertElement(pi, PathElementType.LINE_TO, 17, 6);
@@ -797,23 +797,23 @@ public abstract class AbstractMultiShape2afpTest<T extends MultiShape2afp<?, T, 
 
 	@Override
 	public void operator_andPoint2D() {
-		assertFalse(this.shape.operator_and(createPoint(-10, 2)));
-		assertFalse(this.shape.operator_and(createPoint(-10, 14)));
-		assertFalse(this.shape.operator_and(createPoint(-10, 25)));
-		assertFalse(this.shape.operator_and(createPoint(-1, 25)));
-		assertFalse(this.shape.operator_and(createPoint(1, 2)));
-		assertFalse(this.shape.operator_and(createPoint(12, 2)));
-		assertFalse(this.shape.operator_and(createPoint(12, 14)));
-		assertFalse(this.shape.operator_and(createPoint(12, 25)));
-		assertFalse(this.shape.operator_and(createPoint(-6, 8)));
-		assertFalse(this.shape.operator_and(createPoint(4, 17)));
-		assertTrue(this.shape.operator_and(createPoint(-4, 19)));
-		assertTrue(this.shape.operator_and(createPoint(6, 8.25)));
+		assertFalse(this.shape.operatorAnd(createPoint(-10, 2)));
+		assertFalse(this.shape.operatorAnd(createPoint(-10, 14)));
+		assertFalse(this.shape.operatorAnd(createPoint(-10, 25)));
+		assertFalse(this.shape.operatorAnd(createPoint(-1, 25)));
+		assertFalse(this.shape.operatorAnd(createPoint(1, 2)));
+		assertFalse(this.shape.operatorAnd(createPoint(12, 2)));
+		assertFalse(this.shape.operatorAnd(createPoint(12, 14)));
+		assertFalse(this.shape.operatorAnd(createPoint(12, 25)));
+		assertFalse(this.shape.operatorAnd(createPoint(-6, 8)));
+		assertFalse(this.shape.operatorAnd(createPoint(4, 17)));
+		assertTrue(this.shape.operatorAnd(createPoint(-4, 19)));
+		assertTrue(this.shape.operatorAnd(createPoint(6, 8.25)));
 	}
 
 	@Override
 	public void operator_andShape2D() {
-		assertTrue(this.shape.operator_and(createCircle(4.75, 8, .5)));
+		assertTrue(this.shape.operatorAnd(createCircle(4.75, 8, .5)));
 		Path2afp path = createPath();
 		path.moveTo(-6, 2);
 		path.lineTo(10, 6);
@@ -821,25 +821,25 @@ public abstract class AbstractMultiShape2afpTest<T extends MultiShape2afp<?, T, 
 		path.lineTo(-4, 12);
 		path.lineTo(-12, 22);
 		path.lineTo(6, 20);
-		assertFalse(this.shape.operator_and(path));
+		assertFalse(this.shape.operatorAnd(path));
 		path.closePath();
-		assertTrue(this.shape.operator_and(path));
+		assertTrue(this.shape.operatorAnd(path));
 	}
 
 	@Override
 	public void operator_upToPoint2D() {
-		assertEpsilonEquals(14.76305, this.shape.operator_upTo(createPoint(-10, 2)));
-		assertEpsilonEquals(4.40312, this.shape.operator_upTo(createPoint(-10, 14)));
-		assertEpsilonEquals(6.60233, this.shape.operator_upTo(createPoint(-10, 25)));
-		assertEpsilonEquals(6.06226, this.shape.operator_upTo(createPoint(-1, 25)));
-		assertEpsilonEquals(7.21110, this.shape.operator_upTo(createPoint(1, 2)));
-		assertEpsilonEquals(7.81025, this.shape.operator_upTo(createPoint(12, 2)));
-		assertEpsilonEquals(7.07107, this.shape.operator_upTo(createPoint(12, 14)));
-		assertEpsilonEquals(16.38478, this.shape.operator_upTo(createPoint(12, 25)));
-		assertEpsilonEquals(8.04988, this.shape.operator_upTo(createPoint(-6, 8)));
-		assertEpsilonEquals(7.05538, this.shape.operator_upTo(createPoint(4, 17)));
-		assertEpsilonEquals(0, this.shape.operator_upTo(createPoint(-4, 19)));
-		assertEpsilonEquals(0, this.shape.operator_upTo(createPoint(6, 8.25)));
+		assertEpsilonEquals(14.76305, this.shape.operatorUpTo(createPoint(-10, 2)));
+		assertEpsilonEquals(4.40312, this.shape.operatorUpTo(createPoint(-10, 14)));
+		assertEpsilonEquals(6.60233, this.shape.operatorUpTo(createPoint(-10, 25)));
+		assertEpsilonEquals(6.06226, this.shape.operatorUpTo(createPoint(-1, 25)));
+		assertEpsilonEquals(7.21110, this.shape.operatorUpTo(createPoint(1, 2)));
+		assertEpsilonEquals(7.81025, this.shape.operatorUpTo(createPoint(12, 2)));
+		assertEpsilonEquals(7.07107, this.shape.operatorUpTo(createPoint(12, 14)));
+		assertEpsilonEquals(16.38478, this.shape.operatorUpTo(createPoint(12, 25)));
+		assertEpsilonEquals(8.04988, this.shape.operatorUpTo(createPoint(-6, 8)));
+		assertEpsilonEquals(7.05538, this.shape.operatorUpTo(createPoint(4, 17)));
+		assertEpsilonEquals(0, this.shape.operatorUpTo(createPoint(-4, 19)));
+		assertEpsilonEquals(0, this.shape.operatorUpTo(createPoint(6, 8.25)));
 	}
 
 	@Test

--- a/core/math/src/test/java/org/arakhne/afc/math/geometry/d2/afp/AbstractOrientedRectangle2afpTest.java
+++ b/core/math/src/test/java/org/arakhne/afc/math/geometry/d2/afp/AbstractOrientedRectangle2afpTest.java
@@ -1399,7 +1399,7 @@ public abstract class AbstractOrientedRectangle2afpTest<T extends OrientedRectan
 
 	@Override
 	public void operator_addVector2D() {
-		this.shape.operator_add(createVector(123.456, 789.123));
+		this.shape.operatorAdd(createVector(123.456, 789.123));
 		assertEpsilonEquals(cx + 123.456, this.shape.getCenterX());
 		assertEpsilonEquals(cy + 789.123, this.shape.getCenterY());
 		assertEpsilonEquals(ux, this.shape.getFirstAxisX());
@@ -1412,7 +1412,7 @@ public abstract class AbstractOrientedRectangle2afpTest<T extends OrientedRectan
 
 	@Override
 	public void operator_plusVector2D() {
-		T shape = this.shape.operator_plus(createVector(123.456, 789.123));
+		T shape = this.shape.operatorPlus(createVector(123.456, 789.123));
 		assertEpsilonEquals(cx + 123.456, shape.getCenterX());
 		assertEpsilonEquals(cy + 789.123, shape.getCenterY());
 		assertEpsilonEquals(ux, shape.getFirstAxisX());
@@ -1425,7 +1425,7 @@ public abstract class AbstractOrientedRectangle2afpTest<T extends OrientedRectan
 
 	@Override
 	public void operator_removeVector2D() {
-		this.shape.operator_remove(createVector(123.456, 789.123));
+		this.shape.operatorRemove(createVector(123.456, 789.123));
 		assertEpsilonEquals(cx - 123.456, this.shape.getCenterX());
 		assertEpsilonEquals(cy - 789.123, this.shape.getCenterY());
 		assertEpsilonEquals(ux, this.shape.getFirstAxisX());
@@ -1438,7 +1438,7 @@ public abstract class AbstractOrientedRectangle2afpTest<T extends OrientedRectan
 
 	@Override
 	public void operator_minusVector2D() {
-		T shape = this.shape.operator_minus(createVector(123.456, 789.123));
+		T shape = this.shape.operatorMinus(createVector(123.456, 789.123));
 		assertEpsilonEquals(cx - 123.456, shape.getCenterX());
 		assertEpsilonEquals(cy - 789.123, shape.getCenterY());
 		assertEpsilonEquals(ux, shape.getFirstAxisX());
@@ -1451,7 +1451,7 @@ public abstract class AbstractOrientedRectangle2afpTest<T extends OrientedRectan
 
 	@Override
 	public void operator_multiplyTransform2D() {
-		PathIterator2afp pi = this.shape.operator_multiply(null).getPathIterator();
+		PathIterator2afp pi = this.shape.operatorMultiply(null).getPathIterator();
 		assertElement(pi, PathElementType.MOVE_TO, pGx, pGy);
 		assertElement(pi, PathElementType.LINE_TO, pHx, pHy);
 		assertElement(pi, PathElementType.LINE_TO, pEx, pEy);
@@ -1462,7 +1462,7 @@ public abstract class AbstractOrientedRectangle2afpTest<T extends OrientedRectan
 		Transform2D transform;
 		
 		transform = new Transform2D();
-		pi = this.shape.operator_multiply(transform).getPathIterator();
+		pi = this.shape.operatorMultiply(transform).getPathIterator();
 		assertElement(pi, PathElementType.MOVE_TO, pGx, pGy);
 		assertElement(pi, PathElementType.LINE_TO, pHx, pHy);
 		assertElement(pi, PathElementType.LINE_TO, pEx, pEy);
@@ -1472,7 +1472,7 @@ public abstract class AbstractOrientedRectangle2afpTest<T extends OrientedRectan
 
 		transform = new Transform2D();
 		transform.setTranslation(18,  -45);
-		pi = this.shape.operator_multiply(transform).getPathIterator();
+		pi = this.shape.operatorMultiply(transform).getPathIterator();
 		assertElement(pi, PathElementType.MOVE_TO, pGx + 18, pGy - 45);
 		assertElement(pi, PathElementType.LINE_TO, pHx + 18, pHy - 45);
 		assertElement(pi, PathElementType.LINE_TO, pEx + 18, pEy - 45);
@@ -1484,38 +1484,38 @@ public abstract class AbstractOrientedRectangle2afpTest<T extends OrientedRectan
 
 	@Override
 	public void operator_andPoint2D() {
-		assertTrue(this.shape.operator_and(createPoint(0, 0)));
-		assertFalse(this.shape.operator_and(createPoint(-20, 0)));
-		assertTrue(this.shape.operator_and(createPoint(12, -4)));
-		assertTrue(this.shape.operator_and(createPoint(14, 0)));
-		assertTrue(this.shape.operator_and(createPoint(17, 0)));
-		assertFalse(this.shape.operator_and(createPoint(18, 0)));
-		assertTrue(this.shape.operator_and(createPoint(21, 8)));
-		assertFalse(this.shape.operator_and(createPoint(22, 8)));
-		assertTrue(this.shape.operator_and(createPoint(8, 16)));
-		assertTrue(this.shape.operator_and(createPoint(-4, 20)));
-		assertFalse(this.shape.operator_and(createPoint(-4, 21)));
-		assertTrue(this.shape.operator_and(createPoint(cx, cy)));
-		assertTrue(this.shape.operator_and(createPoint(pEx, pEy)));
+		assertTrue(this.shape.operatorAnd(createPoint(0, 0)));
+		assertFalse(this.shape.operatorAnd(createPoint(-20, 0)));
+		assertTrue(this.shape.operatorAnd(createPoint(12, -4)));
+		assertTrue(this.shape.operatorAnd(createPoint(14, 0)));
+		assertTrue(this.shape.operatorAnd(createPoint(17, 0)));
+		assertFalse(this.shape.operatorAnd(createPoint(18, 0)));
+		assertTrue(this.shape.operatorAnd(createPoint(21, 8)));
+		assertFalse(this.shape.operatorAnd(createPoint(22, 8)));
+		assertTrue(this.shape.operatorAnd(createPoint(8, 16)));
+		assertTrue(this.shape.operatorAnd(createPoint(-4, 20)));
+		assertFalse(this.shape.operatorAnd(createPoint(-4, 21)));
+		assertTrue(this.shape.operatorAnd(createPoint(cx, cy)));
+		assertTrue(this.shape.operatorAnd(createPoint(pEx, pEy)));
 	}
 
 	@Override
 	public void operator_andShape2D() {
-		assertTrue(this.shape.operator_and(createCircle(6, 2, .5)));
-		assertTrue(this.shape.operator_and(createRectangle(4, 4, 2, 1)));
+		assertTrue(this.shape.operatorAnd(createCircle(6, 2, .5)));
+		assertTrue(this.shape.operatorAnd(createRectangle(4, 4, 2, 1)));
 	}
 
 	@Override
 	public void operator_upToPoint2D() {
-		assertEpsilonEquals(9.2551, this.shape.operator_upTo(createPoint(-20, 9)));
-		assertEpsilonEquals(0, this.shape.operator_upTo(createPoint(0, 0)));
-		assertEpsilonEquals(4.44135, this.shape.operator_upTo(createPoint(5, -10)));
-		assertEpsilonEquals(11.18631, this.shape.operator_upTo(createPoint(14, -20)));
-		assertEpsilonEquals(0, this.shape.operator_upTo(createPoint(-6, 15)));
-		assertEpsilonEquals(8.14233, this.shape.operator_upTo(createPoint(0, 35)));
-		assertEpsilonEquals(0, this.shape.operator_upTo(createPoint(10, 0)));
-		assertEpsilonEquals(.75805, this.shape.operator_upTo(createPoint(16, -4)));
-		assertEpsilonEquals(2.99413, this.shape.operator_upTo(createPoint(-5, 25)));
+		assertEpsilonEquals(9.2551, this.shape.operatorUpTo(createPoint(-20, 9)));
+		assertEpsilonEquals(0, this.shape.operatorUpTo(createPoint(0, 0)));
+		assertEpsilonEquals(4.44135, this.shape.operatorUpTo(createPoint(5, -10)));
+		assertEpsilonEquals(11.18631, this.shape.operatorUpTo(createPoint(14, -20)));
+		assertEpsilonEquals(0, this.shape.operatorUpTo(createPoint(-6, 15)));
+		assertEpsilonEquals(8.14233, this.shape.operatorUpTo(createPoint(0, 35)));
+		assertEpsilonEquals(0, this.shape.operatorUpTo(createPoint(10, 0)));
+		assertEpsilonEquals(.75805, this.shape.operatorUpTo(createPoint(16, -4)));
+		assertEpsilonEquals(2.99413, this.shape.operatorUpTo(createPoint(-5, 25)));
 	}
 
 	@Test

--- a/core/math/src/test/java/org/arakhne/afc/math/geometry/d2/afp/AbstractParallelogram2afpTest.java
+++ b/core/math/src/test/java/org/arakhne/afc/math/geometry/d2/afp/AbstractParallelogram2afpTest.java
@@ -1697,7 +1697,7 @@ B extends Rectangle2afp<?, ?, ?, ?, ?, B>> extends AbstractShape2afpTest<T, B> {
 
 	@Override
 	public void operator_addVector2D() {
-		this.shape.operator_add(createVector(123.456, 789.123));
+		this.shape.operatorAdd(createVector(123.456, 789.123));
 		assertEpsilonEquals(cx + 123.456, this.shape.getCenterX());
 		assertEpsilonEquals(cy + 789.123, this.shape.getCenterY());
 		assertEpsilonEquals(ux, this.shape.getFirstAxisX());
@@ -1710,7 +1710,7 @@ B extends Rectangle2afp<?, ?, ?, ?, ?, B>> extends AbstractShape2afpTest<T, B> {
 
 	@Override
 	public void operator_plusVector2D() {
-		T shape = this.shape.operator_plus(createVector(123.456, 789.123));
+		T shape = this.shape.operatorPlus(createVector(123.456, 789.123));
 		assertEpsilonEquals(cx + 123.456, shape.getCenterX());
 		assertEpsilonEquals(cy + 789.123, shape.getCenterY());
 		assertEpsilonEquals(ux, shape.getFirstAxisX());
@@ -1723,7 +1723,7 @@ B extends Rectangle2afp<?, ?, ?, ?, ?, B>> extends AbstractShape2afpTest<T, B> {
 
 	@Override
 	public void operator_removeVector2D() {
-		this.shape.operator_remove(createVector(123.456, 789.123));
+		this.shape.operatorRemove(createVector(123.456, 789.123));
 		assertEpsilonEquals(cx - 123.456, this.shape.getCenterX());
 		assertEpsilonEquals(cy - 789.123, this.shape.getCenterY());
 		assertEpsilonEquals(ux, this.shape.getFirstAxisX());
@@ -1736,7 +1736,7 @@ B extends Rectangle2afp<?, ?, ?, ?, ?, B>> extends AbstractShape2afpTest<T, B> {
 
 	@Override
 	public void operator_minusVector2D() {
-		T shape = this.shape.operator_minus(createVector(123.456, 789.123));
+		T shape = this.shape.operatorMinus(createVector(123.456, 789.123));
 		assertEpsilonEquals(cx - 123.456, shape.getCenterX());
 		assertEpsilonEquals(cy - 789.123, shape.getCenterY());
 		assertEpsilonEquals(ux, shape.getFirstAxisX());
@@ -1749,7 +1749,7 @@ B extends Rectangle2afp<?, ?, ?, ?, ?, B>> extends AbstractShape2afpTest<T, B> {
 
 	@Override
 	public void operator_multiplyTransform2D() {
-		PathIterator2afp pi = this.shape.operator_multiply(null).getPathIterator();
+		PathIterator2afp pi = this.shape.operatorMultiply(null).getPathIterator();
 		assertElement(pi, PathElementType.MOVE_TO, pGx, pGy);
 		assertElement(pi, PathElementType.LINE_TO, pHx, pHy);
 		assertElement(pi, PathElementType.LINE_TO, pEx, pEy);
@@ -1760,7 +1760,7 @@ B extends Rectangle2afp<?, ?, ?, ?, ?, B>> extends AbstractShape2afpTest<T, B> {
 		Transform2D transform;
 		
 		transform = new Transform2D();
-		pi = this.shape.operator_multiply(transform).getPathIterator();
+		pi = this.shape.operatorMultiply(transform).getPathIterator();
 		assertElement(pi, PathElementType.MOVE_TO, pGx, pGy);
 		assertElement(pi, PathElementType.LINE_TO, pHx, pHy);
 		assertElement(pi, PathElementType.LINE_TO, pEx, pEy);
@@ -1770,7 +1770,7 @@ B extends Rectangle2afp<?, ?, ?, ?, ?, B>> extends AbstractShape2afpTest<T, B> {
 
 		transform = new Transform2D();
 		transform.setTranslation(18,  -45);
-		pi = this.shape.operator_multiply(transform).getPathIterator();
+		pi = this.shape.operatorMultiply(transform).getPathIterator();
 		assertElement(pi, PathElementType.MOVE_TO, pGx + 18, pGy - 45);
 		assertElement(pi, PathElementType.LINE_TO, pHx + 18, pHy - 45);
 		assertElement(pi, PathElementType.LINE_TO, pEx + 18, pEy - 45);
@@ -1781,50 +1781,50 @@ B extends Rectangle2afp<?, ?, ?, ?, ?, B>> extends AbstractShape2afpTest<T, B> {
 
 	@Override
 	public void operator_andPoint2D() {
-		assertFalse(this.shape.operator_and(createPoint(0, 0)));
-		assertFalse(this.shape.operator_and(createPoint(-20, 0)));
-		assertTrue(this.shape.operator_and(createPoint(12, -4)));
-		assertTrue(this.shape.operator_and(createPoint(14, 0)));
-		assertFalse(this.shape.operator_and(createPoint(15, 0)));
-		assertFalse(this.shape.operator_and(createPoint(20, 8)));
-		assertTrue(this.shape.operator_and(createPoint(8, 16)));
-		assertFalse(this.shape.operator_and(createPoint(-4, 20)));
-		assertFalse(this.shape.operator_and(createPoint(-5, 12)));
-		assertTrue(this.shape.operator_and(createPoint(0, 6)));
-		assertTrue(this.shape.operator_and(createPoint(0, 7)));
-		assertTrue(this.shape.operator_and(createPoint(0, 8)));
-		assertTrue(this.shape.operator_and(createPoint(0, 9)));
-		assertTrue(this.shape.operator_and(createPoint(0, 10)));
-		assertFalse(this.shape.operator_and(createPoint(0, 27)));
-		assertTrue(this.shape.operator_and(createPoint(cx, cy)));
-		assertTrue(this.shape.operator_and(createPoint( 16, 8)));
+		assertFalse(this.shape.operatorAnd(createPoint(0, 0)));
+		assertFalse(this.shape.operatorAnd(createPoint(-20, 0)));
+		assertTrue(this.shape.operatorAnd(createPoint(12, -4)));
+		assertTrue(this.shape.operatorAnd(createPoint(14, 0)));
+		assertFalse(this.shape.operatorAnd(createPoint(15, 0)));
+		assertFalse(this.shape.operatorAnd(createPoint(20, 8)));
+		assertTrue(this.shape.operatorAnd(createPoint(8, 16)));
+		assertFalse(this.shape.operatorAnd(createPoint(-4, 20)));
+		assertFalse(this.shape.operatorAnd(createPoint(-5, 12)));
+		assertTrue(this.shape.operatorAnd(createPoint(0, 6)));
+		assertTrue(this.shape.operatorAnd(createPoint(0, 7)));
+		assertTrue(this.shape.operatorAnd(createPoint(0, 8)));
+		assertTrue(this.shape.operatorAnd(createPoint(0, 9)));
+		assertTrue(this.shape.operatorAnd(createPoint(0, 10)));
+		assertFalse(this.shape.operatorAnd(createPoint(0, 27)));
+		assertTrue(this.shape.operatorAnd(createPoint(cx, cy)));
+		assertTrue(this.shape.operatorAnd(createPoint( 16, 8)));
 	}
 
 	@Override
 	public void operator_andShape2D() {
-		assertTrue(this.shape.operator_and(createCircle(.5, 3.5, .5)));
-		assertTrue(this.shape.operator_and(createRectangle(12, 14, 1, 1)));
+		assertTrue(this.shape.operatorAnd(createCircle(.5, 3.5, .5)));
+		assertTrue(this.shape.operatorAnd(createRectangle(12, 14, 1, 1)));
 	}
 
 	@Override
 	public void operator_upToPoint2D() {
-		assertEpsilonEquals(14.81966, this.shape.operator_upTo(createPoint(-20, 9)));
-		assertEpsilonEquals(2.7009, this.shape.operator_upTo(createPoint(0, 0)));
-		assertEpsilonEquals(6.23644, this.shape.operator_upTo(createPoint(5, -10)));
-		assertEpsilonEquals(11.1863, this.shape.operator_upTo(createPoint(14, -20)));
-		assertEpsilonEquals(2.25040, this.shape.operator_upTo(createPoint(-6, 15)));
-		assertEpsilonEquals(0, this.shape.operator_upTo(createPoint(0, 10)));
-		assertEpsilonEquals(0, this.shape.operator_upTo(createPoint(10, 0)));
-		assertEpsilonEquals(1.03772, this.shape.operator_upTo(createPoint(15, -4)));
-		assertEpsilonEquals(3.70561, this.shape.operator_upTo(createPoint(-5, 25)));
-		assertEpsilonEquals(0, this.shape.operator_upTo(createPoint(0, 20)));
-		assertEpsilonEquals(0, this.shape.operator_upTo(createPoint(10, 10)));
-		assertEpsilonEquals(4.91829, this.shape.operator_upTo(createPoint(20, 0)));
-		assertEpsilonEquals(8.42901, this.shape.operator_upTo(createPoint(-3, 35)));
-		assertEpsilonEquals(9.91864, this.shape.operator_upTo(createPoint(5, 35)));
-		assertEpsilonEquals(6.23644, this.shape.operator_upTo(createPoint(20, 15)));
-		assertEpsilonEquals(17.8477, this.shape.operator_upTo(createPoint(35, 10)));
-		assertEpsilonEquals(7.59135, this.shape.operator_upTo(createPoint(-8, 29)));
+		assertEpsilonEquals(14.81966, this.shape.operatorUpTo(createPoint(-20, 9)));
+		assertEpsilonEquals(2.7009, this.shape.operatorUpTo(createPoint(0, 0)));
+		assertEpsilonEquals(6.23644, this.shape.operatorUpTo(createPoint(5, -10)));
+		assertEpsilonEquals(11.1863, this.shape.operatorUpTo(createPoint(14, -20)));
+		assertEpsilonEquals(2.25040, this.shape.operatorUpTo(createPoint(-6, 15)));
+		assertEpsilonEquals(0, this.shape.operatorUpTo(createPoint(0, 10)));
+		assertEpsilonEquals(0, this.shape.operatorUpTo(createPoint(10, 0)));
+		assertEpsilonEquals(1.03772, this.shape.operatorUpTo(createPoint(15, -4)));
+		assertEpsilonEquals(3.70561, this.shape.operatorUpTo(createPoint(-5, 25)));
+		assertEpsilonEquals(0, this.shape.operatorUpTo(createPoint(0, 20)));
+		assertEpsilonEquals(0, this.shape.operatorUpTo(createPoint(10, 10)));
+		assertEpsilonEquals(4.91829, this.shape.operatorUpTo(createPoint(20, 0)));
+		assertEpsilonEquals(8.42901, this.shape.operatorUpTo(createPoint(-3, 35)));
+		assertEpsilonEquals(9.91864, this.shape.operatorUpTo(createPoint(5, 35)));
+		assertEpsilonEquals(6.23644, this.shape.operatorUpTo(createPoint(20, 15)));
+		assertEpsilonEquals(17.8477, this.shape.operatorUpTo(createPoint(35, 10)));
+		assertEpsilonEquals(7.59135, this.shape.operatorUpTo(createPoint(-8, 29)));
 	}
 
 	@Test

--- a/core/math/src/test/java/org/arakhne/afc/math/geometry/d2/afp/AbstractPath2afpTest.java
+++ b/core/math/src/test/java/org/arakhne/afc/math/geometry/d2/afp/AbstractPath2afpTest.java
@@ -2225,7 +2225,7 @@ extends AbstractShape2afpTest<T, B> {
 		double dx = getRandom().nextDouble()*20;
 		double dy = getRandom().nextDouble()*20;
 		
-		this.shape.operator_add(createVector(dx, dy));
+		this.shape.operatorAdd(createVector(dx, dy));
 		
 		PathIterator2afp pi = this.shape.getPathIterator();
 		assertElement(pi, PathElementType.MOVE_TO, dx, dy);
@@ -2240,7 +2240,7 @@ extends AbstractShape2afpTest<T, B> {
 		double dx = getRandom().nextDouble()*20;
 		double dy = getRandom().nextDouble()*20;
 		
-		T shape = this.shape.operator_plus(createVector(dx, dy));
+		T shape = this.shape.operatorPlus(createVector(dx, dy));
 		
 		PathIterator2afp pi = shape.getPathIterator();
 		assertElement(pi, PathElementType.MOVE_TO, dx, dy);
@@ -2255,7 +2255,7 @@ extends AbstractShape2afpTest<T, B> {
 		double dx = getRandom().nextDouble()*20;
 		double dy = getRandom().nextDouble()*20;
 		
-		this.shape.operator_remove(createVector(dx, dy));
+		this.shape.operatorRemove(createVector(dx, dy));
 		
 		PathIterator2afp pi = this.shape.getPathIterator();
 		assertElement(pi, PathElementType.MOVE_TO, -dx, -dy);
@@ -2270,7 +2270,7 @@ extends AbstractShape2afpTest<T, B> {
 		double dx = getRandom().nextDouble()*20;
 		double dy = getRandom().nextDouble()*20;
 		
-		T shape = this.shape.operator_minus(createVector(dx, dy));
+		T shape = this.shape.operatorMinus(createVector(dx, dy));
 		
 		PathIterator2afp pi = shape.getPathIterator();
 		assertElement(pi, PathElementType.MOVE_TO, -dx, -dy);
@@ -2298,7 +2298,7 @@ extends AbstractShape2afpTest<T, B> {
 		path.closePath();
 
 		Transform2D trans = new Transform2D(randomMatrix3f());
-		Path2afp transformedShape = (Path2afp) path.operator_multiply(trans);
+		Path2afp transformedShape = (Path2afp) path.operatorMultiply(trans);
 		path.transform(trans);		
 	
 		assertTrue(path.equalsToShape(transformedShape));
@@ -2306,40 +2306,40 @@ extends AbstractShape2afpTest<T, B> {
 
 	@Override
 	public void operator_andPoint2D() {
-		assertFalse(this.shape.operator_and(createPoint(-5, 1)));
-		assertFalse(this.shape.operator_and(createPoint(3, 6)));
-		assertFalse(this.shape.operator_and(createPoint(3, -10)));
-		assertFalse(this.shape.operator_and(createPoint(11, 1)));
-		assertFalse(this.shape.operator_and(createPoint(4, 1)));
-		assertTrue(this.shape.operator_and(createPoint(4, 3)));
+		assertFalse(this.shape.operatorAnd(createPoint(-5, 1)));
+		assertFalse(this.shape.operatorAnd(createPoint(3, 6)));
+		assertFalse(this.shape.operatorAnd(createPoint(3, -10)));
+		assertFalse(this.shape.operatorAnd(createPoint(11, 1)));
+		assertFalse(this.shape.operatorAnd(createPoint(4, 1)));
+		assertTrue(this.shape.operatorAnd(createPoint(4, 3)));
 		this.shape.closePath();
-		assertFalse(this.shape.operator_and(createPoint(-5, 1)));
-		assertFalse(this.shape.operator_and(createPoint(3, 6)));
-		assertFalse(this.shape.operator_and(createPoint(3, -10)));
-		assertFalse(this.shape.operator_and(createPoint(11, 1)));
-		assertTrue(this.shape.operator_and(createPoint(4, 1)));
-		assertTrue(this.shape.operator_and(createPoint(4, 3)));
+		assertFalse(this.shape.operatorAnd(createPoint(-5, 1)));
+		assertFalse(this.shape.operatorAnd(createPoint(3, 6)));
+		assertFalse(this.shape.operatorAnd(createPoint(3, -10)));
+		assertFalse(this.shape.operatorAnd(createPoint(11, 1)));
+		assertTrue(this.shape.operatorAnd(createPoint(4, 1)));
+		assertTrue(this.shape.operatorAnd(createPoint(4, 3)));
 	}
 
 	@Override
 	public void operator_andShape2D() {
-		assertTrue(this.shape.operator_and(createSegment(4, 0, 5, 3)));
-		assertTrue(this.shape.operator_and(createRectangle(1.5, 1.5, 2, 1)));
+		assertTrue(this.shape.operatorAnd(createSegment(4, 0, 5, 3)));
+		assertTrue(this.shape.operatorAnd(createRectangle(1.5, 1.5, 2, 1)));
 	}
 
 	@Override
 	public void operator_upToPoint2D() {
-		assertEpsilonEquals(2.23607, this.shape.operator_upTo(createPoint(-2, 1)));
-		assertEpsilonEquals(.70711, this.shape.operator_upTo(createPoint(1, 0)));
-		assertEpsilonEquals(1.00970, this.shape.operator_upTo(createPoint(3, 0)));
-		assertEpsilonEquals(4.12311, this.shape.operator_upTo(createPoint(1, -4)));
+		assertEpsilonEquals(2.23607, this.shape.operatorUpTo(createPoint(-2, 1)));
+		assertEpsilonEquals(.70711, this.shape.operatorUpTo(createPoint(1, 0)));
+		assertEpsilonEquals(1.00970, this.shape.operatorUpTo(createPoint(3, 0)));
+		assertEpsilonEquals(4.12311, this.shape.operatorUpTo(createPoint(1, -4)));
 		
 		this.shape.closePath();
 		
-		assertEpsilonEquals(2.23606, this.shape.operator_upTo(createPoint(-2, 1)));
-		assertEpsilonEquals(0, this.shape.operator_upTo(createPoint(1, 0)));
-		assertEpsilonEquals(0, this.shape.operator_upTo(createPoint(3, 0)));
-		assertEpsilonEquals(2.6737, this.shape.operator_upTo(createPoint(1, -4)));
+		assertEpsilonEquals(2.23606, this.shape.operatorUpTo(createPoint(-2, 1)));
+		assertEpsilonEquals(0, this.shape.operatorUpTo(createPoint(1, 0)));
+		assertEpsilonEquals(0, this.shape.operatorUpTo(createPoint(3, 0)));
+		assertEpsilonEquals(2.6737, this.shape.operatorUpTo(createPoint(1, -4)));
 	}
 
 	@Test

--- a/core/math/src/test/java/org/arakhne/afc/math/geometry/d2/afp/AbstractRectangle2afpTest.java
+++ b/core/math/src/test/java/org/arakhne/afc/math/geometry/d2/afp/AbstractRectangle2afpTest.java
@@ -1001,7 +1001,7 @@ public abstract class AbstractRectangle2afpTest<T extends Rectangle2afp<?, T, ?,
 
 	@Override
 	public void operator_addVector2D() {
-		this.shape.operator_add(createVector(123.456, 456.789));
+		this.shape.operatorAdd(createVector(123.456, 456.789));
 		assertEpsilonEquals(128.456, this.shape.getMinX());
 		assertEpsilonEquals(464.789, this.shape.getMinY());
 		assertEpsilonEquals(133.456, this.shape.getMaxX());
@@ -1010,7 +1010,7 @@ public abstract class AbstractRectangle2afpTest<T extends Rectangle2afp<?, T, ?,
 
 	@Override
 	public void operator_plusVector2D() {
-		T shape = this.shape.operator_plus(createVector(123.456, 456.789));
+		T shape = this.shape.operatorPlus(createVector(123.456, 456.789));
 		assertEpsilonEquals(128.456, shape.getMinX());
 		assertEpsilonEquals(464.789, shape.getMinY());
 		assertEpsilonEquals(133.456, shape.getMaxX());
@@ -1019,7 +1019,7 @@ public abstract class AbstractRectangle2afpTest<T extends Rectangle2afp<?, T, ?,
 
 	@Override
 	public void operator_removeVector2D() {
-		this.shape.operator_remove(createVector(123.456, 456.789));
+		this.shape.operatorRemove(createVector(123.456, 456.789));
 		assertEpsilonEquals(-118.456, this.shape.getMinX());
 		assertEpsilonEquals(-448.789, this.shape.getMinY());
 		assertEpsilonEquals(-113.456, this.shape.getMaxX());
@@ -1028,7 +1028,7 @@ public abstract class AbstractRectangle2afpTest<T extends Rectangle2afp<?, T, ?,
 
 	@Override
 	public void operator_minusVector2D() {
-		T shape = this.shape.operator_minus(createVector(123.456, 456.789));
+		T shape = this.shape.operatorMinus(createVector(123.456, 456.789));
 		assertEpsilonEquals(-118.456, shape.getMinX());
 		assertEpsilonEquals(-448.789, shape.getMinY());
 		assertEpsilonEquals(-113.456, shape.getMaxX());
@@ -1040,7 +1040,7 @@ public abstract class AbstractRectangle2afpTest<T extends Rectangle2afp<?, T, ?,
 		Transform2D tr;
 		tr = new Transform2D();
 		tr.setTranslation(123.456, 456.789);
-		PathIterator2afp pi = this.shape.operator_multiply(tr).getPathIterator();
+		PathIterator2afp pi = this.shape.operatorMultiply(tr).getPathIterator();
 		assertElement(pi, PathElementType.MOVE_TO, 128.456, 464.789);
 		assertElement(pi, PathElementType.LINE_TO, 133.456, 464.789);
 		assertElement(pi, PathElementType.LINE_TO, 133.456, 474.789);
@@ -1052,43 +1052,43 @@ public abstract class AbstractRectangle2afpTest<T extends Rectangle2afp<?, T, ?,
 	@Override
 	public void operator_andPoint2D() {
 		this.shape.set(10, 12, 30, 25);
-		assertFalse(this.shape.operator_and(createPoint(20, 45)));
-		assertFalse(this.shape.operator_and(createPoint(20, 55)));
-		assertFalse(this.shape.operator_and(createPoint(20, 0)));
-		assertFalse(this.shape.operator_and(createPoint(0, 45)));
-		assertFalse(this.shape.operator_and(createPoint(5, 45)));
-		assertFalse(this.shape.operator_and(createPoint(40, 55)));
-		assertFalse(this.shape.operator_and(createPoint(40, 0)));
-		assertFalse(this.shape.operator_and(createPoint(0, 40)));
-		assertFalse(this.shape.operator_and(createPoint(20, 100)));
-		assertFalse(this.shape.operator_and(createPoint(100, 45)));
-		assertFalse(this.shape.operator_and(createPoint(-100, 45)));
-		assertFalse(this.shape.operator_and(createPoint(-100, 60)));
-		assertTrue(this.shape.operator_and(createPoint(10, 12)));
-		assertTrue(this.shape.operator_and(createPoint(40, 12)));
-		assertTrue(this.shape.operator_and(createPoint(40, 37)));
-		assertTrue(this.shape.operator_and(createPoint(10, 37)));
-		assertTrue(this.shape.operator_and(createPoint(35, 24)));
+		assertFalse(this.shape.operatorAnd(createPoint(20, 45)));
+		assertFalse(this.shape.operatorAnd(createPoint(20, 55)));
+		assertFalse(this.shape.operatorAnd(createPoint(20, 0)));
+		assertFalse(this.shape.operatorAnd(createPoint(0, 45)));
+		assertFalse(this.shape.operatorAnd(createPoint(5, 45)));
+		assertFalse(this.shape.operatorAnd(createPoint(40, 55)));
+		assertFalse(this.shape.operatorAnd(createPoint(40, 0)));
+		assertFalse(this.shape.operatorAnd(createPoint(0, 40)));
+		assertFalse(this.shape.operatorAnd(createPoint(20, 100)));
+		assertFalse(this.shape.operatorAnd(createPoint(100, 45)));
+		assertFalse(this.shape.operatorAnd(createPoint(-100, 45)));
+		assertFalse(this.shape.operatorAnd(createPoint(-100, 60)));
+		assertTrue(this.shape.operatorAnd(createPoint(10, 12)));
+		assertTrue(this.shape.operatorAnd(createPoint(40, 12)));
+		assertTrue(this.shape.operatorAnd(createPoint(40, 37)));
+		assertTrue(this.shape.operatorAnd(createPoint(10, 37)));
+		assertTrue(this.shape.operatorAnd(createPoint(35, 24)));
 	}
 
 	@Override
 	public void operator_andShape2D() {
-		assertTrue(createRectangle(0, 0, 5.1, 100).operator_and(this.shape));
-		assertTrue(createRectangle(.25, .25, .5, .5).operator_and(createEllipse(0, 0, 1, 1)));
+		assertTrue(createRectangle(0, 0, 5.1, 100).operatorAnd(this.shape));
+		assertTrue(createRectangle(.25, .25, .5, .5).operatorAnd(createEllipse(0, 0, 1, 1)));
 	}
 
 	@Override
 	public void operator_upToPoint2D() {
-		assertEpsilonEquals(9.43398, this.shape.operator_upTo(createPoint(0, 0)));
-		assertEpsilonEquals(90.35486, this.shape.operator_upTo(createPoint(100, 0)));
-		assertEpsilonEquals(121.75385, this.shape.operator_upTo(createPoint(100, 100)));
-		assertEpsilonEquals(82.1523, this.shape.operator_upTo(createPoint(0, 100)));
-		assertEpsilonEquals(5, this.shape.operator_upTo(createPoint(0, 10)));
-		assertEpsilonEquals(8, this.shape.operator_upTo(createPoint(7, 0)));
-		assertEpsilonEquals(144, this.shape.operator_upTo(createPoint(154, 17)));
-		assertEpsilonEquals(136, this.shape.operator_upTo(createPoint(9, 154)));
-		assertEpsilonEquals(0, this.shape.operator_upTo(createPoint(8, 18)));
-		assertEpsilonEquals(0, this.shape.operator_upTo(createPoint(7, 12)));
+		assertEpsilonEquals(9.43398, this.shape.operatorUpTo(createPoint(0, 0)));
+		assertEpsilonEquals(90.35486, this.shape.operatorUpTo(createPoint(100, 0)));
+		assertEpsilonEquals(121.75385, this.shape.operatorUpTo(createPoint(100, 100)));
+		assertEpsilonEquals(82.1523, this.shape.operatorUpTo(createPoint(0, 100)));
+		assertEpsilonEquals(5, this.shape.operatorUpTo(createPoint(0, 10)));
+		assertEpsilonEquals(8, this.shape.operatorUpTo(createPoint(7, 0)));
+		assertEpsilonEquals(144, this.shape.operatorUpTo(createPoint(154, 17)));
+		assertEpsilonEquals(136, this.shape.operatorUpTo(createPoint(9, 154)));
+		assertEpsilonEquals(0, this.shape.operatorUpTo(createPoint(8, 18)));
+		assertEpsilonEquals(0, this.shape.operatorUpTo(createPoint(7, 12)));
 	}
 
 	@Test

--- a/core/math/src/test/java/org/arakhne/afc/math/geometry/d2/afp/AbstractRoundRectangle2afpTest.java
+++ b/core/math/src/test/java/org/arakhne/afc/math/geometry/d2/afp/AbstractRoundRectangle2afpTest.java
@@ -905,7 +905,7 @@ public abstract class AbstractRoundRectangle2afpTest<T extends RoundRectangle2af
 
 	@Override
 	public void operator_addVector2D() {
-		this.shape.operator_add(createVector(123.456, 456.789));
+		this.shape.operatorAdd(createVector(123.456, 456.789));
 		assertEpsilonEquals(128.456, this.shape.getMinX());
 		assertEpsilonEquals(464.789, this.shape.getMinY());
 		assertEpsilonEquals(133.456, this.shape.getMaxX());
@@ -914,7 +914,7 @@ public abstract class AbstractRoundRectangle2afpTest<T extends RoundRectangle2af
 
 	@Override
 	public void operator_plusVector2D() {
-		T shape = this.shape.operator_plus(createVector(123.456, 456.789));
+		T shape = this.shape.operatorPlus(createVector(123.456, 456.789));
 		assertEpsilonEquals(128.456, shape.getMinX());
 		assertEpsilonEquals(464.789, shape.getMinY());
 		assertEpsilonEquals(133.456, shape.getMaxX());
@@ -923,7 +923,7 @@ public abstract class AbstractRoundRectangle2afpTest<T extends RoundRectangle2af
 
 	@Override
 	public void operator_removeVector2D() {
-		this.shape.operator_remove(createVector(123.456, 456.789));
+		this.shape.operatorRemove(createVector(123.456, 456.789));
 		assertEpsilonEquals(-118.456, this.shape.getMinX());
 		assertEpsilonEquals(-448.789, this.shape.getMinY());
 		assertEpsilonEquals(-113.456, this.shape.getMaxX());
@@ -932,7 +932,7 @@ public abstract class AbstractRoundRectangle2afpTest<T extends RoundRectangle2af
 
 	@Override
 	public void operator_minusVector2D() {
-		T shape = this.shape.operator_minus(createVector(123.456, 456.789));
+		T shape = this.shape.operatorMinus(createVector(123.456, 456.789));
 		assertEpsilonEquals(-118.456, shape.getMinX());
 		assertEpsilonEquals(-448.789, shape.getMinY());
 		assertEpsilonEquals(-113.456, shape.getMaxX());
@@ -943,7 +943,7 @@ public abstract class AbstractRoundRectangle2afpTest<T extends RoundRectangle2af
 	public void operator_multiplyTransform2D() {
 		PathIterator2afp pi;
 		
-		pi = this.shape.operator_multiply(null).getPathIterator();
+		pi = this.shape.operatorMultiply(null).getPathIterator();
 		assertElement(pi, PathElementType.MOVE_TO, 5.1, 8);
 		assertElement(pi, PathElementType.LINE_TO, 9.9, 8);
 		assertElement(pi, PathElementType.CURVE_TO, 9.95523, 8, 10, 8.08954, 10, 8.2);
@@ -956,7 +956,7 @@ public abstract class AbstractRoundRectangle2afpTest<T extends RoundRectangle2af
 		assertElement(pi, PathElementType.CLOSE, 5.1, 8);
 		assertNoElement(pi);
 
-		pi = this.shape.operator_multiply(new Transform2D()).getPathIterator();
+		pi = this.shape.operatorMultiply(new Transform2D()).getPathIterator();
 		assertElement(pi, PathElementType.MOVE_TO, 5.1, 8);
 		assertElement(pi, PathElementType.LINE_TO, 9.9, 8);
 		assertElement(pi, PathElementType.CURVE_TO, 9.95523, 8, 10, 8.08954, 10, 8.2);
@@ -971,7 +971,7 @@ public abstract class AbstractRoundRectangle2afpTest<T extends RoundRectangle2af
 
 		Transform2D tr = new Transform2D();
 		tr.setTranslation(10, -1);
-		pi = this.shape.operator_multiply(tr).getPathIterator();
+		pi = this.shape.operatorMultiply(tr).getPathIterator();
 		assertElement(pi, PathElementType.MOVE_TO, 15.1, 7);
 		assertElement(pi, PathElementType.LINE_TO, 19.9, 7);
 		assertElement(pi, PathElementType.CURVE_TO, 19.95523, 7, 20, 7.08954, 20, 7.2);
@@ -987,38 +987,38 @@ public abstract class AbstractRoundRectangle2afpTest<T extends RoundRectangle2af
 
 	@Override
 	public void operator_andPoint2D() {
-		assertFalse(this.shape.operator_and(createPoint(0, 0)));
-		assertFalse(this.shape.operator_and(createPoint(20, 0)));
-		assertFalse(this.shape.operator_and(createPoint(20, 20)));
-		assertFalse(this.shape.operator_and(createPoint(0, 20)));
-		assertTrue(this.shape.operator_and(createPoint(8, 13)));
-		assertTrue(this.shape.operator_and(createPoint(5, 13)));
-		assertFalse(this.shape.operator_and(createPoint(4.999, 13)));
-		assertFalse(this.shape.operator_and(createPoint(5, 8)));
-		assertFalse(this.shape.operator_and(createPoint(5, 18)));
-		assertFalse(this.shape.operator_and(createPoint(15, 18)));
-		assertFalse(this.shape.operator_and(createPoint(15, 8)));
+		assertFalse(this.shape.operatorAnd(createPoint(0, 0)));
+		assertFalse(this.shape.operatorAnd(createPoint(20, 0)));
+		assertFalse(this.shape.operatorAnd(createPoint(20, 20)));
+		assertFalse(this.shape.operatorAnd(createPoint(0, 20)));
+		assertTrue(this.shape.operatorAnd(createPoint(8, 13)));
+		assertTrue(this.shape.operatorAnd(createPoint(5, 13)));
+		assertFalse(this.shape.operatorAnd(createPoint(4.999, 13)));
+		assertFalse(this.shape.operatorAnd(createPoint(5, 8)));
+		assertFalse(this.shape.operatorAnd(createPoint(5, 18)));
+		assertFalse(this.shape.operatorAnd(createPoint(15, 18)));
+		assertFalse(this.shape.operatorAnd(createPoint(15, 8)));
 	}
 
 	@Override
 	public void operator_andShape2D() {
-		assertTrue(this.shape.operator_and(createCircle(4.1, 12, 1)));
-		assertTrue(this.shape.operator_and(createEllipse(5, 11.5, 2, 1)));
+		assertTrue(this.shape.operatorAnd(createCircle(4.1, 12, 1)));
+		assertTrue(this.shape.operatorAnd(createEllipse(5, 11.5, 2, 1)));
 	}
 
 	@Override
 	public void operator_upToPoint2D() {
-		assertEpsilonEquals(9.47905, this.shape.operator_upTo(createPoint(0, 0)));
-		assertEpsilonEquals(12.86194, this.shape.operator_upTo(createPoint(20, 0)));
-		assertEpsilonEquals(10.23041, this.shape.operator_upTo(createPoint(20, 20)));
-		assertEpsilonEquals(5.43372, this.shape.operator_upTo(createPoint(0, 20)));
-		assertEpsilonEquals(5, this.shape.operator_upTo(createPoint(0, 11)));
-		assertEpsilonEquals(10, this.shape.operator_upTo(createPoint(20, 11)));
-		assertEpsilonEquals(8, this.shape.operator_upTo(createPoint(7, 0)));
-		assertEpsilonEquals(2, this.shape.operator_upTo(createPoint(7, 20)));
-		assertEpsilonEquals(5, this.shape.operator_upTo(createPoint(0, 8.2)));
-		assertEpsilonEquals(8, this.shape.operator_upTo(createPoint(5.1, 0)));
-		assertEpsilonEquals(0, this.shape.operator_upTo(createPoint(7, 10)));
+		assertEpsilonEquals(9.47905, this.shape.operatorUpTo(createPoint(0, 0)));
+		assertEpsilonEquals(12.86194, this.shape.operatorUpTo(createPoint(20, 0)));
+		assertEpsilonEquals(10.23041, this.shape.operatorUpTo(createPoint(20, 20)));
+		assertEpsilonEquals(5.43372, this.shape.operatorUpTo(createPoint(0, 20)));
+		assertEpsilonEquals(5, this.shape.operatorUpTo(createPoint(0, 11)));
+		assertEpsilonEquals(10, this.shape.operatorUpTo(createPoint(20, 11)));
+		assertEpsilonEquals(8, this.shape.operatorUpTo(createPoint(7, 0)));
+		assertEpsilonEquals(2, this.shape.operatorUpTo(createPoint(7, 20)));
+		assertEpsilonEquals(5, this.shape.operatorUpTo(createPoint(0, 8.2)));
+		assertEpsilonEquals(8, this.shape.operatorUpTo(createPoint(5.1, 0)));
+		assertEpsilonEquals(0, this.shape.operatorUpTo(createPoint(7, 10)));
 	}
 
 	@Test

--- a/core/math/src/test/java/org/arakhne/afc/math/geometry/d2/afp/AbstractSegment2afpTest.java
+++ b/core/math/src/test/java/org/arakhne/afc/math/geometry/d2/afp/AbstractSegment2afpTest.java
@@ -2766,7 +2766,7 @@ B extends Rectangle2afp<?, ?, ?, ?, ?, B>> extends AbstractShape2afpTest<T, B> {
 
 	@Override
 	public void operator_addVector2D() {
-		this.shape.operator_add(createVector(3.4, 4.5));
+		this.shape.operatorAdd(createVector(3.4, 4.5));
 		assertEpsilonEquals(3.4, this.shape.getX1());
 		assertEpsilonEquals(4.5, this.shape.getY1());
 		assertEpsilonEquals(4.4, this.shape.getX2());
@@ -2775,7 +2775,7 @@ B extends Rectangle2afp<?, ?, ?, ?, ?, B>> extends AbstractShape2afpTest<T, B> {
 
 	@Override
 	public void operator_plusVector2D() {
-		T shape = this.shape.operator_plus(createVector(3.4, 4.5));
+		T shape = this.shape.operatorPlus(createVector(3.4, 4.5));
 		assertNotSame(shape, this.shape);
 		assertEpsilonEquals(3.4, shape.getX1());
 		assertEpsilonEquals(4.5, shape.getY1());
@@ -2785,7 +2785,7 @@ B extends Rectangle2afp<?, ?, ?, ?, ?, B>> extends AbstractShape2afpTest<T, B> {
 
 	@Override
 	public void operator_removeVector2D() {
-		this.shape.operator_remove(createVector(3.4, 4.5));
+		this.shape.operatorRemove(createVector(3.4, 4.5));
 		assertEpsilonEquals(-3.4, this.shape.getX1());
 		assertEpsilonEquals(-4.5, this.shape.getY1());
 		assertEpsilonEquals(-2.4, this.shape.getX2());
@@ -2794,7 +2794,7 @@ B extends Rectangle2afp<?, ?, ?, ?, ?, B>> extends AbstractShape2afpTest<T, B> {
 
 	@Override
 	public void operator_minusVector2D() {
-		T shape = this.shape.operator_minus(createVector(3.4, 4.5));
+		T shape = this.shape.operatorMinus(createVector(3.4, 4.5));
 		assertEpsilonEquals(-3.4, shape.getX1());
 		assertEpsilonEquals(-4.5, shape.getY1());
 		assertEpsilonEquals(-2.4, shape.getX2());
@@ -2807,7 +2807,7 @@ B extends Rectangle2afp<?, ?, ?, ?, ?, B>> extends AbstractShape2afpTest<T, B> {
 		Transform2D tr;
 
 		tr = new Transform2D();    	
-		s = (Segment2afp) this.shape.operator_multiply(tr);
+		s = (Segment2afp) this.shape.operatorMultiply(tr);
 		assertEpsilonEquals(0, s.getX1());
 		assertEpsilonEquals(0, s.getY1());
 		assertEpsilonEquals(1, s.getX2());
@@ -2815,7 +2815,7 @@ B extends Rectangle2afp<?, ?, ?, ?, ?, B>> extends AbstractShape2afpTest<T, B> {
 
 		tr = new Transform2D();
 		tr.setTranslation(3.4, 4.5);
-		s = (Segment2afp) this.shape.operator_multiply(tr);
+		s = (Segment2afp) this.shape.operatorMultiply(tr);
 		assertEpsilonEquals(3.4, s.getX1());
 		assertEpsilonEquals(4.5, s.getY1());
 		assertEpsilonEquals(4.4, s.getX2());
@@ -2823,7 +2823,7 @@ B extends Rectangle2afp<?, ?, ?, ?, ?, B>> extends AbstractShape2afpTest<T, B> {
 
 		tr = new Transform2D();
 		tr.setRotation(MathConstants.PI);
-		s = (Segment2afp) this.shape.operator_multiply(tr);
+		s = (Segment2afp) this.shape.operatorMultiply(tr);
 		assertEpsilonEquals(0, s.getX1());
 		assertEpsilonEquals(0, s.getY1());
 		assertEpsilonEquals(-1, s.getX2());
@@ -2831,7 +2831,7 @@ B extends Rectangle2afp<?, ?, ?, ?, ?, B>> extends AbstractShape2afpTest<T, B> {
 
 		tr = new Transform2D();
 		tr.setRotation(MathConstants.QUARTER_PI);
-		s = (Segment2afp) this.shape.operator_multiply(tr);
+		s = (Segment2afp) this.shape.operatorMultiply(tr);
 		assertEpsilonEquals(0, s.getX1());
 		assertEpsilonEquals(0, s.getY1());
 		assertEpsilonEquals(0, s.getX2());
@@ -2840,28 +2840,28 @@ B extends Rectangle2afp<?, ?, ?, ?, ?, B>> extends AbstractShape2afpTest<T, B> {
 
 	@Override
 	public void operator_andPoint2D() {
-		assertTrue(this.shape.operator_and(createPoint(0, 0)));
-		assertTrue(this.shape.operator_and(createPoint(.5, .5)));
-		assertTrue(this.shape.operator_and(createPoint(1, 1)));
-		assertFalse(this.shape.operator_and(createPoint(2.3, 4.5)));
-		assertFalse(this.shape.operator_and(createPoint(2, 2)));
+		assertTrue(this.shape.operatorAnd(createPoint(0, 0)));
+		assertTrue(this.shape.operatorAnd(createPoint(.5, .5)));
+		assertTrue(this.shape.operatorAnd(createPoint(1, 1)));
+		assertFalse(this.shape.operatorAnd(createPoint(2.3, 4.5)));
+		assertFalse(this.shape.operatorAnd(createPoint(2, 2)));
 	}
 
 	@Override
 	public void operator_andShape2D() {
-		assertTrue(this.shape.operator_and(createCircle(0, 0, 1)));
-		assertFalse(this.shape.operator_and(createEllipseFromCorners(5, 2, 6, .5)));
+		assertTrue(this.shape.operatorAnd(createCircle(0, 0, 1)));
+		assertFalse(this.shape.operatorAnd(createEllipseFromCorners(5, 2, 6, .5)));
 	}
 
 	@Override
 	public void operator_upToPoint2D() {
-		assertEpsilonEquals(0, this.shape.operator_upTo(createPoint(0, 0)));
-		assertEpsilonEquals(0, this.shape.operator_upTo(createPoint(.5, .5)));
-		assertEpsilonEquals(0, this.shape.operator_upTo(createPoint(1, 1)));
+		assertEpsilonEquals(0, this.shape.operatorUpTo(createPoint(0, 0)));
+		assertEpsilonEquals(0, this.shape.operatorUpTo(createPoint(.5, .5)));
+		assertEpsilonEquals(0, this.shape.operatorUpTo(createPoint(1, 1)));
 
-		assertEpsilonEquals(3.733630941, this.shape.operator_upTo(createPoint(2.3, 4.5)));
+		assertEpsilonEquals(3.733630941, this.shape.operatorUpTo(createPoint(2.3, 4.5)));
 
-		assertEpsilonEquals(1.414213562, this.shape.operator_upTo(createPoint(2, 2)));
+		assertEpsilonEquals(1.414213562, this.shape.operatorUpTo(createPoint(2, 2)));
 	}
 
 	@Test

--- a/core/math/src/test/java/org/arakhne/afc/math/geometry/d2/afp/AbstractTriangle2afpTest.java
+++ b/core/math/src/test/java/org/arakhne/afc/math/geometry/d2/afp/AbstractTriangle2afpTest.java
@@ -1180,7 +1180,7 @@ public abstract class AbstractTriangle2afpTest<T extends Triangle2afp<?, T, ?, ?
 
 	@Override
 	public void operator_addVector2D() {
-		this.shape.operator_add(createVector(2, -3));
+		this.shape.operatorAdd(createVector(2, -3));
 		assertEpsilonEquals(7, this.shape.getX1());
 		assertEpsilonEquals(5, this.shape.getY1());
 		assertEpsilonEquals(-8, this.shape.getX2());
@@ -1191,7 +1191,7 @@ public abstract class AbstractTriangle2afpTest<T extends Triangle2afp<?, T, ?, ?
 
 	@Override
 	public void operator_plusVector2D() {
-		T shape = this.shape.operator_plus(createVector(2, -3));
+		T shape = this.shape.operatorPlus(createVector(2, -3));
 		assertEpsilonEquals(7, shape.getX1());
 		assertEpsilonEquals(5, shape.getY1());
 		assertEpsilonEquals(-8, shape.getX2());
@@ -1202,7 +1202,7 @@ public abstract class AbstractTriangle2afpTest<T extends Triangle2afp<?, T, ?, ?
 
 	@Override
 	public void operator_removeVector2D() {
-		this.shape.operator_remove(createVector(2, -3));
+		this.shape.operatorRemove(createVector(2, -3));
 		assertEpsilonEquals(3, this.shape.getX1());
 		assertEpsilonEquals(11, this.shape.getY1());
 		assertEpsilonEquals(-12, this.shape.getX2());
@@ -1213,7 +1213,7 @@ public abstract class AbstractTriangle2afpTest<T extends Triangle2afp<?, T, ?, ?
 
 	@Override
 	public void operator_minusVector2D() {
-		T shape = this.shape.operator_minus(createVector(2, -3));
+		T shape = this.shape.operatorMinus(createVector(2, -3));
 		assertEpsilonEquals(3, shape.getX1());
 		assertEpsilonEquals(11, shape.getY1());
 		assertEpsilonEquals(-12, shape.getX2());
@@ -1227,20 +1227,20 @@ public abstract class AbstractTriangle2afpTest<T extends Triangle2afp<?, T, ?, ?
 		Transform2D tr;
 		Shape2afp newShape;
 		
-		newShape = this.shape.operator_multiply(null);
+		newShape = this.shape.operatorMultiply(null);
 		assertNotNull(newShape);
 		assertNotSame(this.shape, newShape);
 		assertEquals(this.shape, newShape);
 
 		tr = new Transform2D();
-		newShape = this.shape.operator_multiply(tr);
+		newShape = this.shape.operatorMultiply(tr);
 		assertNotNull(newShape);
 		assertNotSame(this.shape, newShape);
 		assertEquals(this.shape, newShape);
 
 		tr = new Transform2D();
 		tr.makeTranslationMatrix(10, -10);
-		newShape = this.shape.operator_multiply(tr);
+		newShape = this.shape.operatorMultiply(tr);
 		assertNotNull(newShape);
 		assertNotSame(this.shape, newShape);
 		assertTrue(newShape instanceof Triangle2afp);
@@ -1254,35 +1254,35 @@ public abstract class AbstractTriangle2afpTest<T extends Triangle2afp<?, T, ?, ?
 
 	@Override
 	public void operator_andPoint2D() {
-		assertTrue(this.shape.operator_and(createPoint(0,0)));
-		assertFalse(this.shape.operator_and(createPoint(11,10)));
-		assertFalse(this.shape.operator_and(createPoint(11,50)));
-		assertFalse(this.shape.operator_and(createPoint(9,12)));
-		assertFalse(this.shape.operator_and(createPoint(9,11)));
-		assertFalse(this.shape.operator_and(createPoint(0,6)));
-		assertFalse(this.shape.operator_and(createPoint(8,12)));
-		assertTrue(this.shape.operator_and(createPoint(3,7)));
-		assertFalse(this.shape.operator_and(createPoint(10,11)));
-		assertFalse(this.shape.operator_and(createPoint(9,10)));
-		assertTrue(this.shape.operator_and(createPoint(-4,2)));
-		assertFalse(this.shape.operator_and(createPoint(-8,-5)));
+		assertTrue(this.shape.operatorAnd(createPoint(0,0)));
+		assertFalse(this.shape.operatorAnd(createPoint(11,10)));
+		assertFalse(this.shape.operatorAnd(createPoint(11,50)));
+		assertFalse(this.shape.operatorAnd(createPoint(9,12)));
+		assertFalse(this.shape.operatorAnd(createPoint(9,11)));
+		assertFalse(this.shape.operatorAnd(createPoint(0,6)));
+		assertFalse(this.shape.operatorAnd(createPoint(8,12)));
+		assertTrue(this.shape.operatorAnd(createPoint(3,7)));
+		assertFalse(this.shape.operatorAnd(createPoint(10,11)));
+		assertFalse(this.shape.operatorAnd(createPoint(9,10)));
+		assertTrue(this.shape.operatorAnd(createPoint(-4,2)));
+		assertFalse(this.shape.operatorAnd(createPoint(-8,-5)));
 	}
 
 	@Override
 	public void operator_andShape2D() {
-		assertTrue(this.shape.operator_and(createCircle(5, 8, 1)));
-		assertTrue(this.shape.operator_and(createEllipse(-10, 1, 2, 1)));
+		assertTrue(this.shape.operatorAnd(createCircle(5, 8, 1)));
+		assertTrue(this.shape.operatorAnd(createEllipse(-10, 1, 2, 1)));
 	}
 
 	@Override
 	public void operator_upToPoint2D() {
-		assertEpsilonEquals(0, this.shape.operator_upTo(createPoint(0, 0)));
-		assertEpsilonEquals(5.65685, this.shape.operator_upTo(createPoint(9, 12)));
-		assertEpsilonEquals(0.30206, this.shape.operator_upTo(createPoint(0, 6)));
-		assertEpsilonEquals(10, this.shape.operator_upTo(createPoint(-20, 1)));
-		assertEpsilonEquals(0.63246, this.shape.operator_upTo(createPoint(-6, -1)));
-		assertEpsilonEquals(4, this.shape.operator_upTo(createPoint(-1, -6)));
-		assertEpsilonEquals(3.94446, this.shape.operator_upTo(createPoint(6, 2)));
+		assertEpsilonEquals(0, this.shape.operatorUpTo(createPoint(0, 0)));
+		assertEpsilonEquals(5.65685, this.shape.operatorUpTo(createPoint(9, 12)));
+		assertEpsilonEquals(0.30206, this.shape.operatorUpTo(createPoint(0, 6)));
+		assertEpsilonEquals(10, this.shape.operatorUpTo(createPoint(-20, 1)));
+		assertEpsilonEquals(0.63246, this.shape.operatorUpTo(createPoint(-6, -1)));
+		assertEpsilonEquals(4, this.shape.operatorUpTo(createPoint(-1, -6)));
+		assertEpsilonEquals(3.94446, this.shape.operatorUpTo(createPoint(6, 2)));
 	}
 	
 	@Test

--- a/core/math/src/test/java/org/arakhne/afc/math/geometry/d2/ai/AbstractCircle2aiTest.java
+++ b/core/math/src/test/java/org/arakhne/afc/math/geometry/d2/ai/AbstractCircle2aiTest.java
@@ -814,7 +814,7 @@ public abstract class AbstractCircle2aiTest<T extends Circle2ai<?, T, ?, ?, ?, B
 
 	@Override
 	public void operator_addVector2D() {
-		this.shape.operator_add(createVector(3, 4));
+		this.shape.operatorAdd(createVector(3, 4));
 		assertEquals(8, this.shape.getX());
 		assertEquals(12, this.shape.getY());
 		assertEquals(5, this.shape.getRadius());
@@ -822,7 +822,7 @@ public abstract class AbstractCircle2aiTest<T extends Circle2ai<?, T, ?, ?, ?, B
 
 	@Override
 	public void operator_plusVector2D() {
-		T r = this.shape.operator_plus(createVector(3, 4));
+		T r = this.shape.operatorPlus(createVector(3, 4));
 		assertEquals(8, r.getX());
 		assertEquals(12, r.getY());
 		assertEquals(5, r.getRadius());
@@ -830,7 +830,7 @@ public abstract class AbstractCircle2aiTest<T extends Circle2ai<?, T, ?, ?, ?, B
 
 	@Override
 	public void operator_removeVector2D() {
-		this.shape.operator_remove(createVector(3, 4));
+		this.shape.operatorRemove(createVector(3, 4));
 		assertEquals(2, this.shape.getX());
 		assertEquals(4, this.shape.getY());
 		assertEquals(5, this.shape.getRadius());
@@ -838,7 +838,7 @@ public abstract class AbstractCircle2aiTest<T extends Circle2ai<?, T, ?, ?, ?, B
 
 	@Override
 	public void operator_minusVector2D() {
-		T r = this.shape.operator_minus(createVector(3, 4));
+		T r = this.shape.operatorMinus(createVector(3, 4));
 		assertEquals(2, r.getX());
 		assertEquals(4, r.getY());
 		assertEquals(5, r.getRadius());
@@ -850,7 +850,7 @@ public abstract class AbstractCircle2aiTest<T extends Circle2ai<?, T, ?, ?, ?, B
 		PathIterator2ai<?> pi;
 		
 		tr = new Transform2D();
-		pi = this.shape.operator_multiply(tr).getPathIterator();
+		pi = this.shape.operatorMultiply(tr).getPathIterator();
 		assertElement(pi, PathElementType.MOVE_TO, 10,8);
 		assertElement(pi, PathElementType.CURVE_TO, 10,10, 7,13, 5,13);
 		assertElement(pi, PathElementType.CURVE_TO, 2,13, 0,10, 0,8);
@@ -861,7 +861,7 @@ public abstract class AbstractCircle2aiTest<T extends Circle2ai<?, T, ?, ?, ?, B
 
 		tr = new Transform2D();
 		tr.makeTranslationMatrix(3.4f, 4.5f);
-		pi = this.shape.operator_multiply(tr).getPathIterator();
+		pi = this.shape.operatorMultiply(tr).getPathIterator();
 		assertElement(pi, PathElementType.MOVE_TO, 13,13);
 		assertElement(pi, PathElementType.CURVE_TO, 13,16, 11,18, 8,18);
 		assertElement(pi, PathElementType.CURVE_TO, 5,18, 3,16, 3,13);
@@ -872,7 +872,7 @@ public abstract class AbstractCircle2aiTest<T extends Circle2ai<?, T, ?, ?, ?, B
 
 		tr = new Transform2D();
 		tr.makeRotationMatrix(MathConstants.QUARTER_PI);
-		pi = this.shape.operator_multiply(tr).getPathIterator();
+		pi = this.shape.operatorMultiply(tr).getPathIterator();
 		assertElement(pi, PathElementType.MOVE_TO, 1,13);
 		assertElement(pi, PathElementType.CURVE_TO, -1,15, -4,15, -6,13);
 		assertElement(pi, PathElementType.CURVE_TO, -8,11, -8,8, -6,6);
@@ -884,30 +884,30 @@ public abstract class AbstractCircle2aiTest<T extends Circle2ai<?, T, ?, ?, ?, B
 
 	@Override
 	public void operator_andPoint2D() {
-		assertFalse(this.shape.operator_and(createPoint(0,0)));
-		assertFalse(this.shape.operator_and(createPoint(11,10)));
-		assertFalse(this.shape.operator_and(createPoint(11,50)));
-		assertFalse(this.shape.operator_and(createPoint(9,12)));
-		assertTrue(this.shape.operator_and(createPoint(9,11)));
-		assertTrue(this.shape.operator_and(createPoint(8,12)));
-		assertTrue(this.shape.operator_and(createPoint(3,7)));
-		assertFalse(this.shape.operator_and(createPoint(10,11)));
-		assertTrue(this.shape.operator_and(createPoint(9,10)));
+		assertFalse(this.shape.operatorAnd(createPoint(0,0)));
+		assertFalse(this.shape.operatorAnd(createPoint(11,10)));
+		assertFalse(this.shape.operatorAnd(createPoint(11,50)));
+		assertFalse(this.shape.operatorAnd(createPoint(9,12)));
+		assertTrue(this.shape.operatorAnd(createPoint(9,11)));
+		assertTrue(this.shape.operatorAnd(createPoint(8,12)));
+		assertTrue(this.shape.operatorAnd(createPoint(3,7)));
+		assertFalse(this.shape.operatorAnd(createPoint(10,11)));
+		assertTrue(this.shape.operatorAnd(createPoint(9,10)));
 	}
 
 	@Override
 	public void operator_andShape2D() {
-		assertTrue(this.shape.operator_and(createCircle(0,0,100)));
-		assertTrue(this.shape.operator_and(createRectangle(0,0,100,100)));
+		assertTrue(this.shape.operatorAnd(createCircle(0,0,100)));
+		assertTrue(this.shape.operatorAnd(createRectangle(0,0,100,100)));
 	}
 
 	@Override
 	public void operator_upToPoint2D() {
-		assertEpsilonEquals(0f, this.shape.operator_upTo(createPoint(5,8)));
-		assertEpsilonEquals(0f, this.shape.operator_upTo(createPoint(10,10)));
-		assertEpsilonEquals(0f, this.shape.operator_upTo(createPoint(4,8)));
-		assertEpsilonEquals(4.242640687f, this.shape.operator_upTo(createPoint(0,0)));
-		assertEpsilonEquals(1f, this.shape.operator_upTo(createPoint(5,14)));
+		assertEpsilonEquals(0f, this.shape.operatorUpTo(createPoint(5,8)));
+		assertEpsilonEquals(0f, this.shape.operatorUpTo(createPoint(10,10)));
+		assertEpsilonEquals(0f, this.shape.operatorUpTo(createPoint(4,8)));
+		assertEpsilonEquals(4.242640687f, this.shape.operatorUpTo(createPoint(0,0)));
+		assertEpsilonEquals(1f, this.shape.operatorUpTo(createPoint(5,14)));
 	}
 
 	@Test

--- a/core/math/src/test/java/org/arakhne/afc/math/geometry/d2/ai/AbstractMultiShape2aiTest.java
+++ b/core/math/src/test/java/org/arakhne/afc/math/geometry/d2/ai/AbstractMultiShape2aiTest.java
@@ -622,7 +622,7 @@ public abstract class AbstractMultiShape2aiTest<T extends MultiShape2ai<?, T, C,
 
 	@Override
 	public void operator_addVector2D() {
-		this.shape.operator_add(createVector(10, -2));
+		this.shape.operatorAdd(createVector(10, -2));
 		PathIterator2ai pi = this.shape.getPathIterator();
 		assertElement(pi, PathElementType.MOVE_TO, 15, 6);
 		assertElement(pi, PathElementType.LINE_TO, 17, 6);
@@ -640,7 +640,7 @@ public abstract class AbstractMultiShape2aiTest<T extends MultiShape2ai<?, T, C,
 
 	@Override
 	public void operator_plusVector2D() {
-		T shape = this.shape.operator_plus(createVector(10, -2));
+		T shape = this.shape.operatorPlus(createVector(10, -2));
 		PathIterator2ai pi = shape.getPathIterator();
 		assertElement(pi, PathElementType.MOVE_TO, 15, 6);
 		assertElement(pi, PathElementType.LINE_TO, 17, 6);
@@ -658,7 +658,7 @@ public abstract class AbstractMultiShape2aiTest<T extends MultiShape2ai<?, T, C,
 
 	@Override
 	public void operator_removeVector2D() {
-		this.shape.operator_remove(createVector(10, -2));
+		this.shape.operatorRemove(createVector(10, -2));
 		PathIterator2ai pi = this.shape.getPathIterator();
 		assertElement(pi, PathElementType.MOVE_TO, -5, 10);
 		assertElement(pi, PathElementType.LINE_TO, -3, 10);
@@ -676,7 +676,7 @@ public abstract class AbstractMultiShape2aiTest<T extends MultiShape2ai<?, T, C,
 
 	@Override
 	public void operator_minusVector2D() {
-		T shape = this.shape.operator_minus(createVector(10, -2));
+		T shape = this.shape.operatorMinus(createVector(10, -2));
 		PathIterator2ai pi = shape.getPathIterator();
 		assertElement(pi, PathElementType.MOVE_TO, -5, 10);
 		assertElement(pi, PathElementType.LINE_TO, -3, 10);
@@ -696,7 +696,7 @@ public abstract class AbstractMultiShape2aiTest<T extends MultiShape2ai<?, T, C,
 	public void operator_multiplyTransform2D() {
 		Transform2D transform = new Transform2D();
 		transform.setTranslation(10, -2);
-		Shape2ai newShape = this.shape.operator_multiply(transform);
+		Shape2ai newShape = this.shape.operatorMultiply(transform);
 		PathIterator2ai pi = (PathIterator2ai) newShape.getPathIterator();
 		assertElement(pi, PathElementType.MOVE_TO, 15, 6);
 		assertElement(pi, PathElementType.LINE_TO, 17, 6);
@@ -714,41 +714,41 @@ public abstract class AbstractMultiShape2aiTest<T extends MultiShape2ai<?, T, C,
 
 	@Override
 	public void operator_andPoint2D() {
-		assertFalse(this.shape.operator_and(createPoint(-10, 2)));
-		assertFalse(this.shape.operator_and(createPoint(-10, 14)));
-		assertFalse(this.shape.operator_and(createPoint(-10, 25)));
-		assertFalse(this.shape.operator_and(createPoint(-1, 25)));
-		assertFalse(this.shape.operator_and(createPoint(1, 2)));
-		assertFalse(this.shape.operator_and(createPoint(12, 2)));
-		assertFalse(this.shape.operator_and(createPoint(12, 14)));
-		assertFalse(this.shape.operator_and(createPoint(12, 25)));
-		assertFalse(this.shape.operator_and(createPoint(-6, 8)));
-		assertFalse(this.shape.operator_and(createPoint(4, 17)));
-		assertTrue(this.shape.operator_and(createPoint(-4, 19)));
-		assertTrue(this.shape.operator_and(createPoint(6, 8)));
+		assertFalse(this.shape.operatorAnd(createPoint(-10, 2)));
+		assertFalse(this.shape.operatorAnd(createPoint(-10, 14)));
+		assertFalse(this.shape.operatorAnd(createPoint(-10, 25)));
+		assertFalse(this.shape.operatorAnd(createPoint(-1, 25)));
+		assertFalse(this.shape.operatorAnd(createPoint(1, 2)));
+		assertFalse(this.shape.operatorAnd(createPoint(12, 2)));
+		assertFalse(this.shape.operatorAnd(createPoint(12, 14)));
+		assertFalse(this.shape.operatorAnd(createPoint(12, 25)));
+		assertFalse(this.shape.operatorAnd(createPoint(-6, 8)));
+		assertFalse(this.shape.operatorAnd(createPoint(4, 17)));
+		assertTrue(this.shape.operatorAnd(createPoint(-4, 19)));
+		assertTrue(this.shape.operatorAnd(createPoint(6, 8)));
 	}
 
 	@Override
 	public void operator_andShape2D() {
-		assertTrue(this.shape.operator_and(createCircle(-6, 16, 1)));
-		assertTrue(this.shape.operator_and(createRectangle(-6, 16, 1, 1)));
+		assertTrue(this.shape.operatorAnd(createCircle(-6, 16, 1)));
+		assertTrue(this.shape.operatorAnd(createRectangle(-6, 16, 1, 1)));
 
 	}
 
 	@Override
 	public void operator_upToPoint2D() {
-		assertEpsilonEquals(14.5602, this.shape.operator_upTo(createPoint(-10, 2)));
-		assertEpsilonEquals(4.4721, this.shape.operator_upTo(createPoint(-10, 14)));
-		assertEpsilonEquals(6.4031, this.shape.operator_upTo(createPoint(-10, 25)));
-		assertEpsilonEquals(5.831, this.shape.operator_upTo(createPoint(-1, 25)));
-		assertEpsilonEquals(7.2111, this.shape.operator_upTo(createPoint(1, 2)));
-		assertEpsilonEquals(7.8102, this.shape.operator_upTo(createPoint(12, 2)));
-		assertEpsilonEquals(7.0711, this.shape.operator_upTo(createPoint(12, 14)));
-		assertEpsilonEquals(16.7631, this.shape.operator_upTo(createPoint(12, 25)));
-		assertEpsilonEquals(8, this.shape.operator_upTo(createPoint(-6, 8)));
-		assertEpsilonEquals(7, this.shape.operator_upTo(createPoint(4, 17)));
-		assertEpsilonEquals(0, this.shape.operator_upTo(createPoint(-4, 19)));
-		assertEpsilonEquals(0, this.shape.operator_upTo(createPoint(6, 8)));
+		assertEpsilonEquals(14.5602, this.shape.operatorUpTo(createPoint(-10, 2)));
+		assertEpsilonEquals(4.4721, this.shape.operatorUpTo(createPoint(-10, 14)));
+		assertEpsilonEquals(6.4031, this.shape.operatorUpTo(createPoint(-10, 25)));
+		assertEpsilonEquals(5.831, this.shape.operatorUpTo(createPoint(-1, 25)));
+		assertEpsilonEquals(7.2111, this.shape.operatorUpTo(createPoint(1, 2)));
+		assertEpsilonEquals(7.8102, this.shape.operatorUpTo(createPoint(12, 2)));
+		assertEpsilonEquals(7.0711, this.shape.operatorUpTo(createPoint(12, 14)));
+		assertEpsilonEquals(16.7631, this.shape.operatorUpTo(createPoint(12, 25)));
+		assertEpsilonEquals(8, this.shape.operatorUpTo(createPoint(-6, 8)));
+		assertEpsilonEquals(7, this.shape.operatorUpTo(createPoint(4, 17)));
+		assertEpsilonEquals(0, this.shape.operatorUpTo(createPoint(-4, 19)));
+		assertEpsilonEquals(0, this.shape.operatorUpTo(createPoint(6, 8)));
 	}
 	
 	@Override

--- a/core/math/src/test/java/org/arakhne/afc/math/geometry/d2/ai/AbstractPath2aiTest.java
+++ b/core/math/src/test/java/org/arakhne/afc/math/geometry/d2/ai/AbstractPath2aiTest.java
@@ -1860,7 +1860,7 @@ public abstract class AbstractPath2aiTest<T extends Path2ai<?, T, ?, ?, ?, B>,
 
 	@Override
 	public void operator_addVector2D() {
-		this.shape.operator_add(createVector(3, 4));
+		this.shape.operatorAdd(createVector(3, 4));
 		PathIterator2ai pi = this.shape.getPathIterator();
 		assertElement(pi, PathElementType.MOVE_TO, 3, 4);
 		assertElement(pi, PathElementType.LINE_TO, 5, 6);
@@ -1872,7 +1872,7 @@ public abstract class AbstractPath2aiTest<T extends Path2ai<?, T, ?, ?, ?, B>,
 
 	@Override
 	public void operator_plusVector2D() {
-		T r = this.shape.operator_plus(createVector(3, 4));
+		T r = this.shape.operatorPlus(createVector(3, 4));
 		PathIterator2ai pi = r.getPathIterator();
 		assertElement(pi, PathElementType.MOVE_TO, 3, 4);
 		assertElement(pi, PathElementType.LINE_TO, 5, 6);
@@ -1884,7 +1884,7 @@ public abstract class AbstractPath2aiTest<T extends Path2ai<?, T, ?, ?, ?, B>,
 
 	@Override
 	public void operator_removeVector2D() {
-		this.shape.operator_remove(createVector(3, 4));
+		this.shape.operatorRemove(createVector(3, 4));
 		PathIterator2ai pi = this.shape.getPathIterator();
 		assertElement(pi, PathElementType.MOVE_TO, -3, -4);
 		assertElement(pi, PathElementType.LINE_TO, -1, -2);
@@ -1896,7 +1896,7 @@ public abstract class AbstractPath2aiTest<T extends Path2ai<?, T, ?, ?, ?, B>,
 
 	@Override
 	public void operator_minusVector2D() {
-		T r = this.shape.operator_minus(createVector(3, 4));
+		T r = this.shape.operatorMinus(createVector(3, 4));
 		PathIterator2ai pi = r.getPathIterator();
 		assertElement(pi, PathElementType.MOVE_TO, -3, -4);
 		assertElement(pi, PathElementType.LINE_TO, -1, -2);
@@ -1915,7 +1915,7 @@ public abstract class AbstractPath2aiTest<T extends Path2ai<?, T, ?, ?, ?, B>,
 		Transform2D tr3 = new Transform2D();
 		tr3.mul(tr, tr2);
 
-		Path2ai clone = (Path2ai) this.shape.operator_multiply(tr3);
+		Path2ai clone = (Path2ai) this.shape.operatorMultiply(tr3);
 
 		PathIterator2ai pi = (PathIterator2ai) clone.getPathIterator();
 		assertElement(pi, PathElementType.MOVE_TO, 3, 4);
@@ -1928,30 +1928,30 @@ public abstract class AbstractPath2aiTest<T extends Path2ai<?, T, ?, ?, ?, B>,
 
 	@Override
 	public void operator_andPoint2D() {
-		assertTrue(this.shape.operator_and(createPoint(0, 0)));
-		assertTrue(this.shape.operator_and(createPoint(4, 3)));
-		assertTrue(this.shape.operator_and(createPoint(2, 2)));
-		assertTrue(this.shape.operator_and(createPoint( 2, 1)));
-		assertTrue(this.shape.operator_and(createPoint(4, 2)));
-		assertFalse(this.shape.operator_and(createPoint(-1, -1)));
-		assertFalse(this.shape.operator_and(createPoint(6, 2)));
-		assertTrue(this.shape.operator_and(createPoint(3, -2)));
-		assertFalse(this.shape.operator_and(createPoint(2, -2)));
+		assertTrue(this.shape.operatorAnd(createPoint(0, 0)));
+		assertTrue(this.shape.operatorAnd(createPoint(4, 3)));
+		assertTrue(this.shape.operatorAnd(createPoint(2, 2)));
+		assertTrue(this.shape.operatorAnd(createPoint( 2, 1)));
+		assertTrue(this.shape.operatorAnd(createPoint(4, 2)));
+		assertFalse(this.shape.operatorAnd(createPoint(-1, -1)));
+		assertFalse(this.shape.operatorAnd(createPoint(6, 2)));
+		assertTrue(this.shape.operatorAnd(createPoint(3, -2)));
+		assertFalse(this.shape.operatorAnd(createPoint(2, -2)));
 	}
 
 	@Override
 	public void operator_andShape2D() {
-		assertTrue(this.shape.operator_and(createCircle(3, 0, 1)));
-		assertTrue(this.shape.operator_and(createRectangle(-1, -1, 1, 1)));
+		assertTrue(this.shape.operatorAnd(createCircle(3, 0, 1)));
+		assertTrue(this.shape.operatorAnd(createRectangle(-1, -1, 1, 1)));
 	}
 
 	@Override
 	public void operator_upToPoint2D() {
-		assertEpsilonEquals(0f, this.shape.operator_upTo(createPoint(0, 0)));
-		assertEpsilonEquals(0f, this.shape.operator_upTo(createPoint(1, 0)));
-		assertEpsilonEquals(7.071067812f, this.shape.operator_upTo(createPoint(-5, -5)));
-		assertEpsilonEquals(3f, this.shape.operator_upTo(createPoint(4, 6)));
-		assertEpsilonEquals(1f, this.shape.operator_upTo(createPoint(7, 0)));
+		assertEpsilonEquals(0f, this.shape.operatorUpTo(createPoint(0, 0)));
+		assertEpsilonEquals(0f, this.shape.operatorUpTo(createPoint(1, 0)));
+		assertEpsilonEquals(7.071067812f, this.shape.operatorUpTo(createPoint(-5, -5)));
+		assertEpsilonEquals(3f, this.shape.operatorUpTo(createPoint(4, 6)));
+		assertEpsilonEquals(1f, this.shape.operatorUpTo(createPoint(7, 0)));
 	}
 
 	@Test

--- a/core/math/src/test/java/org/arakhne/afc/math/geometry/d2/ai/AbstractRectangle2aiTest.java
+++ b/core/math/src/test/java/org/arakhne/afc/math/geometry/d2/ai/AbstractRectangle2aiTest.java
@@ -849,7 +849,7 @@ public abstract class AbstractRectangle2aiTest<T extends Rectangle2ai<?, T, ?, ?
 
 	@Override
 	public void operator_addVector2D() {
-		this.shape.operator_add(createVector(3, 4));
+		this.shape.operatorAdd(createVector(3, 4));
 		assertEquals(8, this.shape.getMinX());
 		assertEquals(12, this.shape.getMinY());
 		assertEquals(18, this.shape.getMaxX());
@@ -858,7 +858,7 @@ public abstract class AbstractRectangle2aiTest<T extends Rectangle2ai<?, T, ?, ?
 
 	@Override
 	public void operator_plusVector2D() {
-		T r = this.shape.operator_plus(createVector(3, 4));
+		T r = this.shape.operatorPlus(createVector(3, 4));
 		assertEquals(8, r.getMinX());
 		assertEquals(12, r.getMinY());
 		assertEquals(18, r.getMaxX());
@@ -867,7 +867,7 @@ public abstract class AbstractRectangle2aiTest<T extends Rectangle2ai<?, T, ?, ?
 
 	@Override
 	public void operator_removeVector2D() {
-		this.shape.operator_remove(createVector(3, 4));
+		this.shape.operatorRemove(createVector(3, 4));
 		assertEquals(2, this.shape.getMinX());
 		assertEquals(4, this.shape.getMinY());
 		assertEquals(12, this.shape.getMaxX());
@@ -876,7 +876,7 @@ public abstract class AbstractRectangle2aiTest<T extends Rectangle2ai<?, T, ?, ?
 
 	@Override
 	public void operator_minusVector2D() {
-		T r = this.shape.operator_minus(createVector(3, 4));
+		T r = this.shape.operatorMinus(createVector(3, 4));
 		assertEquals(2, r.getMinX());
 		assertEquals(4, r.getMinY());
 		assertEquals(12, r.getMaxX());
@@ -889,7 +889,7 @@ public abstract class AbstractRectangle2aiTest<T extends Rectangle2ai<?, T, ?, ?
 		PathIterator2ai pi;
 		
 		tr = new Transform2D();
-		pi = this.shape.operator_multiply(tr).getPathIterator();
+		pi = this.shape.operatorMultiply(tr).getPathIterator();
 		assertElement(pi, PathElementType.MOVE_TO, 5,8);
 		assertElement(pi, PathElementType.LINE_TO, 15,8);
 		assertElement(pi, PathElementType.LINE_TO, 15,13);
@@ -899,7 +899,7 @@ public abstract class AbstractRectangle2aiTest<T extends Rectangle2ai<?, T, ?, ?
 
 		tr = new Transform2D();
 		tr.makeTranslationMatrix(3.4f, 4.5f);
-		pi = this.shape.operator_multiply(tr).getPathIterator();
+		pi = this.shape.operatorMultiply(tr).getPathIterator();
 		assertElement(pi, PathElementType.MOVE_TO, 8,13);
 		assertElement(pi, PathElementType.LINE_TO, 18,13);
 		assertElement(pi, PathElementType.LINE_TO, 18,18);
@@ -909,7 +909,7 @@ public abstract class AbstractRectangle2aiTest<T extends Rectangle2ai<?, T, ?, ?
 
 		tr = new Transform2D();
 		tr.makeRotationMatrix(MathConstants.QUARTER_PI);		
-		pi = this.shape.operator_multiply(tr).getPathIterator();
+		pi = this.shape.operatorMultiply(tr).getPathIterator();
 		assertElement(pi, PathElementType.MOVE_TO, -2,9);
 		assertElement(pi, PathElementType.LINE_TO, 5,16);
 		assertElement(pi, PathElementType.LINE_TO, 1,20);
@@ -920,23 +920,23 @@ public abstract class AbstractRectangle2aiTest<T extends Rectangle2ai<?, T, ?, ?
 
 	@Override
 	public void operator_andPoint2D() {
-		assertFalse(this.shape.operator_and(createPoint(0,0)));
-		assertTrue(this.shape.operator_and(createPoint(11,10)));
-		assertFalse(this.shape.operator_and(createPoint(11,50)));
+		assertFalse(this.shape.operatorAnd(createPoint(0,0)));
+		assertTrue(this.shape.operatorAnd(createPoint(11,10)));
+		assertFalse(this.shape.operatorAnd(createPoint(11,50)));
 	}
 
 	@Override
 	public void operator_andShape2D() {
-		assertTrue(this.shape.operator_and(createCircle(0,0,100)));
-		assertTrue(this.shape.operator_and(createRectangle(7,10,1,1)));
+		assertTrue(this.shape.operatorAnd(createCircle(0,0,100)));
+		assertTrue(this.shape.operatorAnd(createRectangle(7,10,1,1)));
 	}
 
 	@Override
 	public void operator_upToPoint2D() {
-		assertEpsilonEquals(0f, this.shape.operator_upTo(createPoint(5,8)));
-		assertEpsilonEquals(0f, this.shape.operator_upTo(createPoint(10,10)));
-		assertEpsilonEquals(1f, this.shape.operator_upTo(createPoint(4,8)));
-		assertEpsilonEquals(9.433981132f, this.shape.operator_upTo(createPoint(0,0)));
+		assertEpsilonEquals(0f, this.shape.operatorUpTo(createPoint(5,8)));
+		assertEpsilonEquals(0f, this.shape.operatorUpTo(createPoint(10,10)));
+		assertEpsilonEquals(1f, this.shape.operatorUpTo(createPoint(4,8)));
+		assertEpsilonEquals(9.433981132f, this.shape.operatorUpTo(createPoint(0,0)));
 	}
 
 	@Test

--- a/core/math/src/test/java/org/arakhne/afc/math/geometry/d2/ai/AbstractSegment2aiTest.java
+++ b/core/math/src/test/java/org/arakhne/afc/math/geometry/d2/ai/AbstractSegment2aiTest.java
@@ -1032,7 +1032,7 @@ public abstract class AbstractSegment2aiTest<T extends Segment2ai<?, T, ?, ?, ?,
 
 	@Override
 	public void operator_addVector2D() {
-		this.shape.operator_add(createVector(3, 4));
+		this.shape.operatorAdd(createVector(3, 4));
 		assertEquals(3, this.shape.getX1());
 		assertEquals(4, this.shape.getY1());
 		assertEquals(13, this.shape.getX2());
@@ -1041,7 +1041,7 @@ public abstract class AbstractSegment2aiTest<T extends Segment2ai<?, T, ?, ?, ?,
 
 	@Override
 	public void operator_plusVector2D() {
-		T r = this.shape.operator_plus(createVector(3, 4));
+		T r = this.shape.operatorPlus(createVector(3, 4));
 		assertEquals(3, r.getX1());
 		assertEquals(4, r.getY1());
 		assertEquals(13, r.getX2());
@@ -1050,7 +1050,7 @@ public abstract class AbstractSegment2aiTest<T extends Segment2ai<?, T, ?, ?, ?,
 
 	@Override
 	public void operator_removeVector2D() {
-		this.shape.operator_remove(createVector(3, 4));
+		this.shape.operatorRemove(createVector(3, 4));
 		assertEquals(-3, this.shape.getX1());
 		assertEquals(-4, this.shape.getY1());
 		assertEquals(7, this.shape.getX2());
@@ -1059,7 +1059,7 @@ public abstract class AbstractSegment2aiTest<T extends Segment2ai<?, T, ?, ?, ?,
 
 	@Override
 	public void operator_minusVector2D() {
-		T r = this.shape.operator_minus(createVector(3, 4));
+		T r = this.shape.operatorMinus(createVector(3, 4));
 		assertEquals(-3, r.getX1());
 		assertEquals(-4, r.getY1());
 		assertEquals(7, r.getX2());
@@ -1072,7 +1072,7 @@ public abstract class AbstractSegment2aiTest<T extends Segment2ai<?, T, ?, ?, ?,
     	Transform2D tr;
     	
     	tr = new Transform2D();    	
-    	s = (T) this.shape.operator_multiply(tr);
+    	s = (T) this.shape.operatorMultiply(tr);
 		assertEquals(0, s.getX1());
 		assertEquals(0, s.getY1());
 		assertEquals(10, s.getX2());
@@ -1080,7 +1080,7 @@ public abstract class AbstractSegment2aiTest<T extends Segment2ai<?, T, ?, ?, ?,
 
     	tr = new Transform2D();
     	tr.setTranslation(3.4f, 4.5f);
-    	s = (T) this.shape.operator_multiply(tr);
+    	s = (T) this.shape.operatorMultiply(tr);
 		assertEquals(3, s.getX1());
 		assertEquals(5, s.getY1());
 		assertEquals(13, s.getX2());
@@ -1088,7 +1088,7 @@ public abstract class AbstractSegment2aiTest<T extends Segment2ai<?, T, ?, ?, ?,
 
     	tr = new Transform2D();
     	tr.setRotation(MathConstants.PI);
-    	s = (T) this.shape.operator_multiply(tr);
+    	s = (T) this.shape.operatorMultiply(tr);
 		assertEquals(0, s.getX1());
 		assertEquals(0, s.getY1());
 		assertEquals(-10, s.getX2());
@@ -1096,7 +1096,7 @@ public abstract class AbstractSegment2aiTest<T extends Segment2ai<?, T, ?, ?, ?,
 
     	tr = new Transform2D();
     	tr.setRotation(MathConstants.QUARTER_PI);
-    	s = (T) this.shape.operator_multiply(tr);
+    	s = (T) this.shape.operatorMultiply(tr);
 		assertEquals(0, s.getX1());
 		assertEquals(0, s.getY1());
 		assertEquals(4, s.getX2());
@@ -1105,33 +1105,33 @@ public abstract class AbstractSegment2aiTest<T extends Segment2ai<?, T, ?, ?, ?,
 
 	@Override
 	public void operator_andPoint2D() {
-		assertTrue(this.shape.operator_and(createPoint(0, 0)));
-		assertTrue(this.shape.operator_and(createPoint(10, 5)));
+		assertTrue(this.shape.operatorAnd(createPoint(0, 0)));
+		assertTrue(this.shape.operatorAnd(createPoint(10, 5)));
 		
-		assertFalse(this.shape.operator_and(createPoint(1, 1)));
-		assertFalse(this.shape.operator_and(createPoint(2, 4)));
+		assertFalse(this.shape.operatorAnd(createPoint(1, 1)));
+		assertFalse(this.shape.operatorAnd(createPoint(2, 4)));
 
-		assertFalse(this.shape.operator_and(createPoint(2, 2)));
+		assertFalse(this.shape.operatorAnd(createPoint(2, 2)));
 
-		assertTrue(this.shape.operator_and(createPoint(1, 0)));
+		assertTrue(this.shape.operatorAnd(createPoint(1, 0)));
 
-		assertFalse(this.shape.operator_and(createPoint(5, 3)));
-		assertTrue(this.shape.operator_and(createPoint(5, 2)));
+		assertFalse(this.shape.operatorAnd(createPoint(5, 3)));
+		assertTrue(this.shape.operatorAnd(createPoint(5, 2)));
 	}
 
 	@Override
 	public void operator_andShape2D() {
-		assertTrue(this.shape.operator_and(createCircle(16,0,100)));
-		assertTrue(this.shape.operator_and(createRectangle(0,0,100,100)));
+		assertTrue(this.shape.operatorAnd(createCircle(16,0,100)));
+		assertTrue(this.shape.operatorAnd(createRectangle(0,0,100,100)));
 	}
 
 	@Override
 	public void operator_upToPoint2D() {
-		assertEpsilonEquals(0f, this.shape.operator_upTo(createPoint(0, 0)));
-		assertEpsilonEquals(1f, this.shape.operator_upTo(createPoint(1, 1)));
-		assertEpsilonEquals(2.828427125f, this.shape.operator_upTo(createPoint(2, 4)));
-		assertEpsilonEquals(1f, this.shape.operator_upTo(createPoint(2, 2)));
-		assertEpsilonEquals(7.071067812f, this.shape.operator_upTo(createPoint(-5, 5)));
+		assertEpsilonEquals(0f, this.shape.operatorUpTo(createPoint(0, 0)));
+		assertEpsilonEquals(1f, this.shape.operatorUpTo(createPoint(1, 1)));
+		assertEpsilonEquals(2.828427125f, this.shape.operatorUpTo(createPoint(2, 4)));
+		assertEpsilonEquals(1f, this.shape.operatorUpTo(createPoint(2, 2)));
+		assertEpsilonEquals(7.071067812f, this.shape.operatorUpTo(createPoint(-5, 5)));
 	}
 
 	@Test


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S00100 - “Method names should comply with a naming convention”. 
This PR will remove 280 min TD.
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S00100
 Please let me know if you have any questions.
Fevzi Ozgul