### PR TITLE
Fixing squid: S1149 Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used Part 1

### DIFF
--- a/core/math/src/main/java/org/arakhne/afc/math/graph/DepthFirstGraphCourseModel.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/graph/DepthFirstGraphCourseModel.java
@@ -20,8 +20,9 @@
 
 package org.arakhne.afc.math.graph;
 
+import java.util.ArrayDeque;
 import java.util.Collection;
-import java.util.Stack;
+import java.util.Deque;
 
 import org.eclipse.xtext.xbase.lib.Pure;
 
@@ -40,7 +41,7 @@ import org.eclipse.xtext.xbase.lib.Pure;
 public class DepthFirstGraphCourseModel<ST extends GraphSegment<ST, PT>, PT extends GraphPoint<PT, ST>>
 		implements GraphCourseModel<ST, PT> {
 
-	private final Stack<GraphIterationElement<ST, PT>> stack = new Stack<>();
+	private final Deque<GraphIterationElement<ST, PT>> stack = new ArrayDeque<>();
 
 	/** Replies if this model restitutes the elements in a reverse order.
 	 *

--- a/core/math/src/main/java/org/arakhne/afc/math/tree/iterator/AbstractInfixDepthFirstTreeIterator.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/tree/iterator/AbstractInfixDepthFirstTreeIterator.java
@@ -20,12 +20,13 @@
 
 package org.arakhne.afc.math.tree.iterator;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.ConcurrentModificationException;
+import java.util.Deque;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.Stack;
 
 import org.eclipse.xtext.xbase.lib.Pure;
 
@@ -69,7 +70,7 @@ public abstract class AbstractInfixDepthFirstTreeIterator<P extends IterableNode
 
 	/** List of the node to treat.
 	 */
-	private final Stack<P> availableNodes = new Stack<>();
+	private final Deque<P> availableNodes = new ArrayDeque<>();
 
 	/** List of expanded nodes.
 	 */

--- a/core/math/src/main/java/org/arakhne/afc/math/tree/iterator/AbstractPostfixDepthFirstTreeIterator.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/tree/iterator/AbstractPostfixDepthFirstTreeIterator.java
@@ -20,12 +20,13 @@
 
 package org.arakhne.afc.math.tree.iterator;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.ConcurrentModificationException;
+import java.util.Deque;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.Stack;
 
 import org.eclipse.xtext.xbase.lib.Pure;
 
@@ -49,7 +50,7 @@ public abstract class AbstractPostfixDepthFirstTreeIterator<P extends IterableNo
 
 	/** List of the node to treat.
 	 */
-	private final Stack<P> availableNodes = new Stack<>();
+	private final Deque<P> availableNodes = new ArrayDeque<>();
 
 	/** List of expanded nodes.
 	 */

--- a/core/math/src/main/java/org/arakhne/afc/math/tree/iterator/AbstractPrefixDepthFirstTreeIterator.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/tree/iterator/AbstractPrefixDepthFirstTreeIterator.java
@@ -20,10 +20,11 @@
 
 package org.arakhne.afc.math.tree.iterator;
 
+import java.util.ArrayDeque;
 import java.util.ConcurrentModificationException;
+import java.util.Deque;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
-import java.util.Stack;
 
 import org.eclipse.xtext.xbase.lib.Pure;
 
@@ -45,7 +46,7 @@ import org.arakhne.afc.math.tree.IterableNode;
 public abstract class AbstractPrefixDepthFirstTreeIterator<P extends IterableNode<? extends C>, C extends IterableNode<?>>
 		implements Iterator<P> {
 
-	private final Stack<P> availableNodes = new Stack<>();
+	private final Deque<P> availableNodes = new ArrayDeque<>();
 
 	private boolean isStarted;
 

--- a/core/vmutils/src/main/java/org/arakhne/afc/vmutil/ThreadServiceFinder.java
+++ b/core/vmutils/src/main/java/org/arakhne/afc/vmutil/ThreadServiceFinder.java
@@ -20,8 +20,9 @@
 
 package org.arakhne.afc.vmutil;
 
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.EmptyStackException;
-import java.util.Stack;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -38,7 +39,7 @@ import org.eclipse.xtext.xbase.lib.Pure;
  */
 public final class ThreadServiceFinder {
 
-	private static final Stack<ThreadServiceProvider> SERVICES = new Stack<>();
+	private static final Deque<ThreadServiceProvider> SERVICES = new ArrayDeque<>();
 
 	static {
 		// Add the default provider


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1149 - “Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used ”. 
This PR will remove 100min TD.
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1149
 Please let me know if you have any questions.
Fevzi Ozgul