### PR TITLE
Fixing squid: S229 Null pointers should not be deferenced  Part 1--- PR#53  reworked

### DIFF
--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/ImmutablePoint2D.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/ImmutablePoint2D.java
@@ -65,7 +65,7 @@ public final class ImmutablePoint2D implements UnmodifiablePoint2D<ImmutablePoin
 	@Pure
 	@Override
 	public boolean equals(Object object) {
-		if(object == this) {
+		if (object == this) {
 			return true;
 		}
 		if (getClass().isInstance(object)) {

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/ImmutablePoint2D.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/ImmutablePoint2D.java
@@ -65,14 +65,14 @@ public final class ImmutablePoint2D implements UnmodifiablePoint2D<ImmutablePoin
 	@Pure
 	@Override
 	public boolean equals(Object object) {
-		try {
+		if(object == this) {
+			return true;
+		}
+		if (getClass().isInstance(object)) {
 			final Tuple2D<?> tuple = (Tuple2D<?>) object;
 			return tuple.getX() == getX() && tuple.getY() == getY();
-		} catch (AssertionError e) {
-			throw e;
-		} catch (Throwable e2) {
-			return false;
 		}
+		return false;
 	}
 
 	@Pure

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/ImmutableVector2D.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/ImmutableVector2D.java
@@ -61,7 +61,7 @@ public final class ImmutableVector2D implements UnmodifiableVector2D<ImmutableVe
 	@Override
 	public boolean equals(Object object) {
 
-		if(object == this) {
+		if (object == this) {
 			return true;
 		}
 		if (getClass().isInstance(object)) {

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/ImmutableVector2D.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/ImmutableVector2D.java
@@ -60,14 +60,15 @@ public final class ImmutableVector2D implements UnmodifiableVector2D<ImmutableVe
 	@Pure
 	@Override
 	public boolean equals(Object object) {
-		try {
+
+		if(object == this) {
+			return true;
+		}
+		if (getClass().isInstance(object)) {
 			final Tuple2D<?> tuple = (Tuple2D<?>) object;
 			return tuple.getX() == getX() && tuple.getY() == getY();
-		} catch (AssertionError e) {
-			throw e;
-		} catch (Throwable e2) {
-			return false;
 		}
+		return false;
 	}
 
 	@Override

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/Tuple2D.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/Tuple2D.java
@@ -598,14 +598,11 @@ public interface Tuple2D<RT extends Tuple2D<? super RT>> extends Cloneable, Seri
 	 */
 	@Pure
 	default boolean equals(Tuple2D<?> tuple) {
-		if (tuple == this) {
-			return true;
+		try {
+			return getX() == tuple.getX() && getY() == tuple.getY();
+		} catch (Throwable exception) {
+			return false;
 		}
-		if (getClass().isInstance(tuple)) {
-			final Tuple2D<?> object = (Tuple2D<?>) tuple;
-			return object.getX() == getX() && object.getY() == getY();
-		}
-		return false;
 	}
 
 	/**

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/Tuple2D.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/Tuple2D.java
@@ -598,7 +598,7 @@ public interface Tuple2D<RT extends Tuple2D<? super RT>> extends Cloneable, Seri
 	 */
 	@Pure
 	default boolean equals(Tuple2D<?> tuple) {
-		if(tuple == this) {
+		if (tuple == this) {
 			return true;
 		}
 		if (getClass().isInstance(tuple)) {

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/Tuple2D.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/Tuple2D.java
@@ -598,11 +598,14 @@ public interface Tuple2D<RT extends Tuple2D<? super RT>> extends Cloneable, Seri
 	 */
 	@Pure
 	default boolean equals(Tuple2D<?> tuple) {
-		try {
-			return getX() == tuple.getX() && getY() == tuple.getY();
-		} catch (Throwable exception) {
-			return false;
+		if(tuple == this) {
+			return true;
 		}
+		if (getClass().isInstance(tuple)) {
+			final Tuple2D<?> object = (Tuple2D<?>) tuple;
+			return object.getX() == getX() && object.getY() == getY();
+		}
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
 This PR is improved version of PR#53 which we had  closed to produce  an new PR using Java way of equals method creation. 
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S2259 - “Null pointers should not be dereferenced”. 
This PR will remove 80 min TD: 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S2259
 Please let me know if you have any questions.
Fevzi Ozgul