### PR TITLE
Fixing squid: S1192 String literals should not be duplicated 

### DIFF
--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/PathElement2dfx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/PathElement2dfx.java
@@ -45,6 +45,8 @@ import org.arakhne.afc.vmutil.asserts.AssertMessages;
 public abstract class PathElement2dfx implements PathElement2afp {
 	private static final long serialVersionUID = 1724746568685625149L;
 
+	private static final String OPEN_CLOSE_PARENTHESES = ")\n\tto: (";
+
 	/** Type of the element.
 	 */
 	protected final PathElementType type;
@@ -544,7 +546,7 @@ public abstract class PathElement2dfx implements PathElement2afp {
 		public String toString() {
 			return "LINE\n\tfrom: (" //$NON-NLS-1$
 					+ getFromX() + ", " //$NON-NLS-1$
-					+ getFromY() + ")\n\tto: (" //$NON-NLS-1$
+					+ getFromY() + OPEN_CLOSE_PARENTHESES //$NON-NLS-1$
 					+ getToX() + ", " //$NON-NLS-1$
 					+ getToY() + ")\n"; //$NON-NLS-1$
 		}
@@ -723,7 +725,7 @@ public abstract class PathElement2dfx implements PathElement2afp {
 					+ getFromX() + ", " //$NON-NLS-1$
 					+ getFromY() + ")\n\tctrl: (" //$NON-NLS-1$
 					+ getCtrlX1() + ", " //$NON-NLS-1$
-					+ getCtrlY1() + ")\n\tto: (" //$NON-NLS-1$
+					+ getCtrlY1() + OPEN_CLOSE_PARENTHESES //$NON-NLS-1$
 					+ getToX() + ", " //$NON-NLS-1$
 					+ getToY() + ")"; //$NON-NLS-1$
 		}
@@ -952,7 +954,7 @@ public abstract class PathElement2dfx implements PathElement2afp {
 					+ getCtrlX1() + ", " //$NON-NLS-1$
 					+ getCtrlY1() + ")\n\tctrl 2: (" //$NON-NLS-1$
 					+ getCtrlX2() + ", " //$NON-NLS-1$
-					+ getCtrlY2() + ")\n\tto: (" //$NON-NLS-1$
+					+ getCtrlY2() + OPEN_CLOSE_PARENTHESES //$NON-NLS-1$
 					+ this.getToX() + ", " //$NON-NLS-1$
 					+ this.getToY() + ")"; //$NON-NLS-1$
 		}
@@ -1340,7 +1342,7 @@ public abstract class PathElement2dfx implements PathElement2afp {
 		public String toString() {
 			return "ARC:\n\tfrom: (" //$NON-NLS-1$
 					+ getFromX() + ", " //$NON-NLS-1$
-					+ getFromY() + ")\n\tto: (" //$NON-NLS-1$
+					+ getFromY() + OPEN_CLOSE_PARENTHESES //$NON-NLS-1$
 					+ getToX() + ", " //$NON-NLS-1$
 					+ getToY() + ")\n\tx radius: " //$NON-NLS-1$
 					+ getRadiusX() + "\n\ty radius: " //$NON-NLS-1$

--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/ifx/PathElement2ifx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/ifx/PathElement2ifx.java
@@ -46,6 +46,8 @@ public abstract class PathElement2ifx implements PathElement2ai {
 
 	private static final long serialVersionUID = -5532787413347691238L;
 
+	private static final String OPEN_CLOSE_PARENTHESES = ")\n\tto: (";
+
 	/** Type of the element.
 	 */
 	protected final PathElementType type;
@@ -545,7 +547,7 @@ public abstract class PathElement2ifx implements PathElement2ai {
 		public String toString() {
 			return "LINE\n\tfrom: (" //$NON-NLS-1$
 					+ getFromX() + ", " //$NON-NLS-1$
-					+ getFromY() + ")\n\tto: (" //$NON-NLS-1$
+					+ getFromY() + OPEN_CLOSE_PARENTHESES //$NON-NLS-1$
 					+ getToX() + ", " //$NON-NLS-1$
 					+ getToY() + ")\n"; //$NON-NLS-1$
 		}
@@ -723,7 +725,7 @@ public abstract class PathElement2ifx implements PathElement2ai {
 					+ getFromX() + ", " //$NON-NLS-1$
 					+ getFromY() + ")\n\tctrl: (" //$NON-NLS-1$
 					+ getCtrlX1() + ", " //$NON-NLS-1$
-					+ getCtrlY1() + ")\n\tto: (" //$NON-NLS-1$
+					+ getCtrlY1() + OPEN_CLOSE_PARENTHESES //$NON-NLS-1$
 					+ getToX() + ", " //$NON-NLS-1$
 					+ getToY() + ")"; //$NON-NLS-1$
 		}
@@ -949,7 +951,7 @@ public abstract class PathElement2ifx implements PathElement2ai {
 					+ getCtrlX1() + ", " //$NON-NLS-1$
 					+ getCtrlY1() + ")\n\tctrl 2: (" //$NON-NLS-1$
 					+ getCtrlX2() + ", " //$NON-NLS-1$
-					+ getCtrlY2() + ")\n\tto: (" //$NON-NLS-1$
+					+ getCtrlY2() + OPEN_CLOSE_PARENTHESES //$NON-NLS-1$
 					+ this.getToX() + ", " //$NON-NLS-1$
 					+ this.getToY() + ")"; //$NON-NLS-1$
 		}
@@ -1338,7 +1340,7 @@ public abstract class PathElement2ifx implements PathElement2ai {
 		public String toString() {
 			return "ARC:\n\tfrom: (" //$NON-NLS-1$
 					+ getFromX() + ", " //$NON-NLS-1$
-					+ getFromY() + ")\n\tto: (" //$NON-NLS-1$
+					+ getFromY() + OPEN_CLOSE_PARENTHESES //$NON-NLS-1$
 					+ getToX() + ", " //$NON-NLS-1$
 					+ getToY() + ")\n\tx radius: " //$NON-NLS-1$
 					+ getRadiusX() + "\n\ty radius: " //$NON-NLS-1$

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/afp/Path2afp.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/afp/Path2afp.java
@@ -62,6 +62,11 @@ public interface Path2afp<
         V extends Vector2D<? super V, ? super P>, B extends Rectangle2afp<?, ?, IE, P, V, B>>
         extends Shape2afp<ST, IT, IE, P, V, B>, Path2D<ST, IT, PathIterator2afp<IE>, P, V, B> {
 
+    /**
+     * String literal.
+     */
+    String IS_CURVED = "isCurved";
+
     /** Multiple of cubic & quad curve size.
      */
     int GROW_SIZE = 24;
@@ -233,7 +238,7 @@ public interface Path2afp<
      */
     static void getClosestPointTo(PathIterator2afp<? extends PathElement2afp> pi, double x, double y, Point2D<?, ?> result) {
         assert pi != null : AssertMessages.notNullParameter(0);
-        assert !pi.isCurved() : AssertMessages.invalidTrueValue(0, "isCurved"); //$NON-NLS-1$
+        assert !pi.isCurved() : AssertMessages.invalidTrueValue(0, IS_CURVED); //$NON-NLS-1$
         assert result != null : AssertMessages.notNullParameter(3);
         double bestDist = Double.POSITIVE_INFINITY;
         PathElement2afp pe;
@@ -317,7 +322,7 @@ public interface Path2afp<
             PathIterator2afp<? extends PathElement2afp> shape, Point2D<?, ?> result) {
         assert pi != null : AssertMessages.notNullParameter(0);
         assert shape != null : AssertMessages.notNullParameter(1);
-        assert !pi.isCurved() : AssertMessages.invalidTrueValue(0, "isCurved"); //$NON-NLS-1$
+        assert !pi.isCurved() : AssertMessages.invalidTrueValue(0, IS_CURVED); //$NON-NLS-1$
         assert result != null : AssertMessages.notNullParameter(2);
         if (!pi.hasNext() || !shape.hasNext()) {
             return false;
@@ -545,7 +550,7 @@ public interface Path2afp<
      */
     static void getFarthestPointTo(PathIterator2afp<? extends PathElement2afp> pi, double x, double y, Point2D<?, ?> result) {
         assert pi != null : AssertMessages.notNullParameter(0);
-        assert !pi.isCurved() : AssertMessages.invalidTrueValue(0, "isCurved"); //$NON-NLS-1$
+        assert !pi.isCurved() : AssertMessages.invalidTrueValue(0, IS_CURVED); //$NON-NLS-1$
         assert result != null : AssertMessages.notNullParameter(3);
         double bestDist = Double.NEGATIVE_INFINITY;
         PathElement2afp pe;

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/d/PathElement2d.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/d/PathElement2d.java
@@ -39,6 +39,8 @@ public abstract class PathElement2d implements PathElement2afp {
 
 	private static final long serialVersionUID = -9217295344283468162L;
 
+	private static final String OPEN_CLOSE_PARENTHESES = ")\n\tto: (";
+
 	/** Type of the element.
 	 */
 	protected final PathElementType type;
@@ -340,7 +342,7 @@ public abstract class PathElement2d implements PathElement2afp {
 		public String toString() {
 			return "LINE\n\tfrom: (" //$NON-NLS-1$
 					+ getFromX() + ", " //$NON-NLS-1$
-					+ getFromY() + ")\n\tto: (" //$NON-NLS-1$
+					+ getFromY() + OPEN_CLOSE_PARENTHESES //$NON-NLS-1$
 					+ getToX() + ", " //$NON-NLS-1$
 					+ getToY() + ")\n"; //$NON-NLS-1$
 		}
@@ -479,7 +481,7 @@ public abstract class PathElement2d implements PathElement2afp {
 					+ getFromX() + ", " //$NON-NLS-1$
 					+ getFromY() + ")\n\tctrl: (" //$NON-NLS-1$
 					+ getCtrlX1() + ", " //$NON-NLS-1$
-					+ getCtrlY1() + ")\n\tto: (" //$NON-NLS-1$
+					+ getCtrlY1() + OPEN_CLOSE_PARENTHESES //$NON-NLS-1$
 					+ getToX() + ", " //$NON-NLS-1$
 					+ getToY() + ")"; //$NON-NLS-1$
 		}
@@ -649,7 +651,7 @@ public abstract class PathElement2d implements PathElement2afp {
 					+ getCtrlX1() + ", " //$NON-NLS-1$
 					+ getCtrlY1() + ")\n\tctrl 2: (" //$NON-NLS-1$
 					+ getCtrlX2() + ", " //$NON-NLS-1$
-					+ getCtrlY2() + ")\n\tto: (" //$NON-NLS-1$
+					+ getCtrlY2() + OPEN_CLOSE_PARENTHESES //$NON-NLS-1$
 					+ this.getToX() + ", " //$NON-NLS-1$
 					+ this.getToY() + ")"; //$NON-NLS-1$
 		}
@@ -941,7 +943,7 @@ public abstract class PathElement2d implements PathElement2afp {
 		public String toString() {
 			return "ARC:\n\tfrom: (" //$NON-NLS-1$
 					+ getFromX() + ", " //$NON-NLS-1$
-					+ getFromY() + ")\n\tto: (" //$NON-NLS-1$
+					+ getFromY() + OPEN_CLOSE_PARENTHESES //$NON-NLS-1$
 					+ getToX() + ", " //$NON-NLS-1$
 					+ getToY() + ")\n\tx radius: " //$NON-NLS-1$
 					+ getRadiusX() + "\n\ty radius: " //$NON-NLS-1$

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/i/PathElement2i.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/i/PathElement2i.java
@@ -39,6 +39,8 @@ public abstract class PathElement2i implements PathElement2ai {
 
 	private static final long serialVersionUID = -7762354100984227855L;
 
+	private static final String OPEN_CLOSE_PARENTHESES = ")\n\tto: (";
+
 	/** Type of the element.
 	 */
 	protected final PathElementType type;
@@ -335,7 +337,7 @@ public abstract class PathElement2i implements PathElement2ai {
 		public String toString() {
 			return "LINE\n\tfrom: (" //$NON-NLS-1$
 					+ getFromX() + ", " //$NON-NLS-1$
-					+ getFromY() + ")\n\tto: (" //$NON-NLS-1$
+					+ getFromY() + OPEN_CLOSE_PARENTHESES //$NON-NLS-1$
 					+ getToX() + ", " //$NON-NLS-1$
 					+ getToY() + ")\n"; //$NON-NLS-1$
 		}
@@ -466,7 +468,7 @@ public abstract class PathElement2i implements PathElement2ai {
 					+ getFromX() + ", " //$NON-NLS-1$
 					+ getFromY() + ")\n\tctrl: (" //$NON-NLS-1$
 					+ getCtrlX1() + ", " //$NON-NLS-1$
-					+ getCtrlY1() + ")\n\tto: (" //$NON-NLS-1$
+					+ getCtrlY1() + OPEN_CLOSE_PARENTHESES //$NON-NLS-1$
 					+ getToX() + ", " //$NON-NLS-1$
 					+ getToY() + ")"; //$NON-NLS-1$
 		}
@@ -626,7 +628,7 @@ public abstract class PathElement2i implements PathElement2ai {
 					+ getCtrlX1() + ", " //$NON-NLS-1$
 					+ getCtrlY1() + ")\n\tctrl 2: (" //$NON-NLS-1$
 					+ getCtrlX2() + ", " //$NON-NLS-1$
-					+ getCtrlY2() + ")\n\tto: (" //$NON-NLS-1$
+					+ getCtrlY2() + OPEN_CLOSE_PARENTHESES //$NON-NLS-1$
 					+ this.getToX() + ", " //$NON-NLS-1$
 					+ this.getToY() + ")"; //$NON-NLS-1$
 		}
@@ -912,7 +914,7 @@ public abstract class PathElement2i implements PathElement2ai {
 		public String toString() {
 			return "ARC:\n\tfrom: (" //$NON-NLS-1$
 					+ getFromX() + ", " //$NON-NLS-1$
-					+ getFromY() + ")\n\tto: (" //$NON-NLS-1$
+					+ getFromY() + OPEN_CLOSE_PARENTHESES //$NON-NLS-1$
 					+ getToX() + ", " //$NON-NLS-1$
 					+ getToY() + ")\n\tx radius: " //$NON-NLS-1$
 					+ getRadiusX() + "\n\ty radius: " //$NON-NLS-1$

--- a/core/math/src/main/java/org/arakhne/afc/math/matrix/Transform2D.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/matrix/Transform2D.java
@@ -50,6 +50,8 @@ public class Transform2D extends Matrix3d {
 
 	private static final long serialVersionUID = -3437760883865605968L;
 
+	private static final String DETERMINANT = "Determinant is ";
+
 	/**
 	 * Constructs a new Transform2D object and sets it to the identity transformation.
 	 */
@@ -775,7 +777,7 @@ public class Transform2D extends Matrix3d {
 	public Transform2D createInverse() {
 		float det = (float)(this.m00 * this.m11 - this.m01 * this.m10);
 		if (Math.abs(det) <= Double.MIN_VALUE) {
-			throw new SingularMatrixException("Determinant is "+det); //$NON-NLS-1$
+			throw new SingularMatrixException(DETERMINANT+det); //$NON-NLS-1$
 		}
 		return new Transform2D(
 				(float)(this.m11 / det),
@@ -827,7 +829,7 @@ public class Transform2D extends Matrix3d {
 	public void invert() {
 		float det = (float)(this.m00 * this.m11 - this.m01 * this.m10);
 		if (Math.abs(det) <= Double.MIN_VALUE) {
-			throw new SingularMatrixException("Determinant is "+det); //$NON-NLS-1$
+			throw new SingularMatrixException(DETERMINANT+det); //$NON-NLS-1$
 		}
 		set(
 				(float)(this.m11 / det),
@@ -860,7 +862,7 @@ public class Transform2D extends Matrix3d {
 	public void invert(Matrix3d m) {
 		float det = (float)(m.m00 * m.m11 - m.m01 * m.m10);
 		if (Math.abs(det) <= Double.MIN_VALUE) {
-			throw new SingularMatrixException("Determinant is "+det); //$NON-NLS-1$
+			throw new SingularMatrixException(DETERMINANT+det); //$NON-NLS-1$
 		}
 		set(
 				(float)(m.m11 / det),

--- a/core/testtools/src/main/java/org/arakhne/afc/testtools/AbstractTestCase.java
+++ b/core/testtools/src/main/java/org/arakhne/afc/testtools/AbstractTestCase.java
@@ -61,6 +61,8 @@ public abstract class AbstractTestCase extends EnableAssertion {
 	 */
 	public static final double EPSILON = 10 * 1.110223024E-16;
 
+	private static final String EXPECTING_ZERO = "Expecting zero";
+
 	private int decimalPrecision = DEFAULT_DECIMAL_COUNT;
 
 	/** Random number sequence.
@@ -235,7 +237,7 @@ public abstract class AbstractTestCase extends EnableAssertion {
 	 */
 	public static void assertZero(byte value) {
 		if (value != 0) {
-			fail(formatFailMessage(null, "Expecting zero", value)); //$NON-NLS-1$
+			fail(formatFailMessage(null, EXPECTING_ZERO, value)); //$NON-NLS-1$
 		}
 	}
 
@@ -245,7 +247,7 @@ public abstract class AbstractTestCase extends EnableAssertion {
 	 */
 	public static void assertZero(short value) {
 		if (value != 0) {
-			fail(formatFailMessage(null, "Expecting zero", value)); //$NON-NLS-1$
+			fail(formatFailMessage(null, EXPECTING_ZERO, value)); //$NON-NLS-1$
 		}
 	}
 
@@ -255,7 +257,7 @@ public abstract class AbstractTestCase extends EnableAssertion {
 	 */
 	public static void assertZero(int value) {
 		if (value != 0) {
-			fail(formatFailMessage(null, "Expecting zero", value)); //$NON-NLS-1$
+			fail(formatFailMessage(null, EXPECTING_ZERO, value)); //$NON-NLS-1$
 		}
 	}
 
@@ -265,7 +267,7 @@ public abstract class AbstractTestCase extends EnableAssertion {
 	 */
 	public static void assertZero(long value) {
 		if (value != 0) {
-			fail(formatFailMessage(null, "Expecting zero", value)); //$NON-NLS-1$
+			fail(formatFailMessage(null, EXPECTING_ZERO, value)); //$NON-NLS-1$
 		}
 	}
 
@@ -275,7 +277,7 @@ public abstract class AbstractTestCase extends EnableAssertion {
 	 */
 	public static void assertZero(float value) {
 		if (value != 0f) {
-			fail(formatFailMessage(null, "Expecting zero", value)); //$NON-NLS-1$
+			fail(formatFailMessage(null, EXPECTING_ZERO, value)); //$NON-NLS-1$
 		}
 	}
 
@@ -294,7 +296,7 @@ public abstract class AbstractTestCase extends EnableAssertion {
 	 */
 	public static void assertZero(String message, double value) {
 		if (value != 0.) {
-			fail(formatFailMessage(message, "Expecting zero", value)); //$NON-NLS-1$
+			fail(formatFailMessage(message, EXPECTING_ZERO, value)); //$NON-NLS-1$
 		}
 	}
 
@@ -313,7 +315,7 @@ public abstract class AbstractTestCase extends EnableAssertion {
 	 */
 	public void assertEpsilonZero(String message, double value) {
 		if (!isEpsilonEquals(value, 0.)) {
-			fail(formatFailMessage(message, "Expecting zero", value)); //$NON-NLS-1$
+			fail(formatFailMessage(message, EXPECTING_ZERO, value)); //$NON-NLS-1$
 		}
 	}
 

--- a/core/text/src/main/java/org/arakhne/afc/text/TextUtil.java
+++ b/core/text/src/main/java/org/arakhne/afc/text/TextUtil.java
@@ -57,6 +57,8 @@ public final class TextUtil {
 
 	private static SoftReference<Map<Character, String>> javaToHtmlTransTbl;
 
+	private static final String SPLIT_REGEX = "(\\}\\{)|\\{|\\}";
+
 	private TextUtil() {
 		//
 	}
@@ -149,7 +151,7 @@ public final class TextUtil {
 
 		map = new TreeMap<>();
 
-		final String[] pairs = result.split("(\\}\\{)|\\{|\\}"); //$NON-NLS-1$
+		final String[] pairs = result.split(SPLIT_REGEX); //$NON-NLS-1$
 		Integer isoCode;
 		String entity;
 		String code;
@@ -222,7 +224,7 @@ public final class TextUtil {
 
 		map = new TreeMap<>();
 
-		final String[] pairs = result.split("(\\}\\{)|\\{|\\}"); //$NON-NLS-1$
+		final String[] pairs = result.split(SPLIT_REGEX); //$NON-NLS-1$
 		Integer isoCode;
 		String entity;
 		String code;
@@ -523,7 +525,7 @@ public final class TextUtil {
 
 		map = new TreeMap<>();
 
-		final String[] pairs = result.split("(\\}\\{)|\\{|\\}"); //$NON-NLS-1$
+		final String[] pairs = result.split(SPLIT_REGEX); //$NON-NLS-1$
 		for (final String pair : pairs) {
 			if (pair.length() > 1) {
 				map.put(pair.charAt(0), pair.substring(1));

--- a/core/vmutils/src/main/java/org/arakhne/afc/vmutil/OperatingSystem.java
+++ b/core/vmutils/src/main/java/org/arakhne/afc/vmutil/OperatingSystem.java
@@ -101,6 +101,8 @@ public enum OperatingSystem {
 	private static String osUUID;
 	private static OperatingSystem currentOSInstance;
 
+	private static final String OS_NAME = "os.name";
+
 	//@SuppressWarnings("checkstyle:cyclomaticcomplexity")
 	static {
 		OperatingSystemIdentificationType type = OperatingSystemIdentificationType.BIOS;
@@ -133,7 +135,7 @@ public enum OperatingSystem {
 			try {
 				LibraryLoader.loadPlatformDependentLibrary(
 						"josuuid", //$NON-NLS-1$
-						System.getProperty("os.name").trim().toLowerCase(), //$NON-NLS-1$
+						System.getProperty(OS_NAME).trim().toLowerCase(), //$NON-NLS-1$
 						"org/arakhne/vmutil"); //$NON-NLS-1$
 				nativeWrapper = new OperatingSystemNativeWrapper(type);
 			} catch (Throwable e) {
@@ -202,7 +204,7 @@ public enum OperatingSystem {
 	@Pure
 	@Inline("System.getProperty(\"os.name\")")
 	public static String getCurrentOSName() {
-		return System.getProperty("os.name"); //$NON-NLS-1$
+		return System.getProperty(OS_NAME); //$NON-NLS-1$
 	}
 
 	/** Replies the version of the current OS.
@@ -237,7 +239,7 @@ public enum OperatingSystem {
 	@SuppressWarnings("checkstyle:cyclomaticcomplexity")
 	public static OperatingSystem getCurrentOS() {
 		if (currentOSInstance == null) {
-			final String os = System.getProperty("os.name").trim().toLowerCase(); //$NON-NLS-1$
+			final String os = System.getProperty(OS_NAME).trim().toLowerCase(); //$NON-NLS-1$
 			/* Let's try to figure canonical OS name, just in case some
 			 * JVMs use funny values (unlikely)
 			 */

--- a/core/vmutils/src/main/java/org/arakhne/afc/vmutil/file/URLConnection.java
+++ b/core/vmutils/src/main/java/org/arakhne/afc/vmutil/file/URLConnection.java
@@ -65,9 +65,16 @@ import org.arakhne.afc.vmutil.locale.Locale;
  */
 class URLConnection extends java.net.URLConnection {
 
+	private static final String CONTENT_LENGTH = "content-length";
+
+	private static final String CONTENT_TYPE = "content-type";
+
+	private static final String LAST_MODIFIED = "last-modified";
+
 	private File file;
 
 	private String contentType;
+
 
 	/**
 	 * @param url is the "file"-protocol url to use.
@@ -106,13 +113,13 @@ class URLConnection extends java.net.URLConnection {
 		} catch (IOException e) {
 			throw new IllegalStateException(e);
 		}
-    	if ("content-type".equals(name)) { //$NON-NLS-1$
+    	if (CONTENT_TYPE.equals(name)) { //$NON-NLS-1$
     		return this.contentType;
     	}
-    	if ("content-length".equals(name)) { //$NON-NLS-1$
+    	if (CONTENT_LENGTH.equals(name)) { //$NON-NLS-1$
     		return Long.toString(this.file.length());
     	}
-    	if ("last-modified".equals(name)) { //$NON-NLS-1$
+    	if (LAST_MODIFIED.equals(name)) { //$NON-NLS-1$
     		return Long.toString(this.file.lastModified());
     	}
     	return null;
@@ -123,11 +130,11 @@ class URLConnection extends java.net.URLConnection {
 		assert index >= 0 : AssertMessages.positiveOrZeroParameter();
     	switch (index) {
     	case 0:
-    		return "content-type"; //$NON-NLS-1$
+    		return CONTENT_TYPE; //$NON-NLS-1$
     	case 1:
-    		return "content-length"; //$NON-NLS-1$
+    		return CONTENT_LENGTH; //$NON-NLS-1$
     	case 2:
-    		return "last-modified"; //$NON-NLS-1$
+    		return LAST_MODIFIED; //$NON-NLS-1$
     	default:
     	}
     	return null;
@@ -141,9 +148,9 @@ class URLConnection extends java.net.URLConnection {
 			throw new IllegalStateException(e);
 		}
 		final Map<String, List<String>> flds = new HashMap<>();
-    	flds.put("content-type", singletonList(this.contentType)); //$NON-NLS-1$
-    	flds.put("content-length", singletonList(Long.toString(this.file.length()))); //$NON-NLS-1$
-    	flds.put("last-modified", singletonList(Long.toString(this.file.lastModified()))); //$NON-NLS-1$
+    	flds.put(CONTENT_TYPE, singletonList(this.contentType)); //$NON-NLS-1$
+    	flds.put(CONTENT_LENGTH, singletonList(Long.toString(this.file.length()))); //$NON-NLS-1$
+    	flds.put(LAST_MODIFIED, singletonList(Long.toString(this.file.lastModified()))); //$NON-NLS-1$
         return flds;
     }
 

--- a/maven/maventools/src/main/java/org/arakhne/maven/ExtendedArtifact.java
+++ b/maven/maventools/src/main/java/org/arakhne/maven/ExtendedArtifact.java
@@ -59,6 +59,8 @@ public final class ExtendedArtifact implements Artifact {
 	 */
 	public static final String EMPTY_STRING = ""; //$NON-NLS-1$
 
+	private static final String EMAIL_TEXT = ";EMAIL=";
+
 	private final String artifactName;
 
 	private final Artifact original;
@@ -192,7 +194,7 @@ public final class ExtendedArtifact implements Artifact {
 							"Comparing '" + login //$NON-NLS-1$
 							+ " to the developer [ID=" + devel.getId() //$NON-NLS-1$
 							+ ";NAME=" + devel.getName() //$NON-NLS-1$
-							+ ";EMAIL=" + devel.getEmail() //$NON-NLS-1$
+							+ EMAIL_TEXT + devel.getEmail() //$NON-NLS-1$
 							+ "]"); //$NON-NLS-1$
 				}
 				String idprop = null;
@@ -211,7 +213,7 @@ public final class ExtendedArtifact implements Artifact {
 						logger.debug(
 								"Selecting the developer [ID=" + devel.getId() //$NON-NLS-1$
 								+ ";NAME=" + devel.getName() //$NON-NLS-1$
-								+ ";EMAIL=" + devel.getEmail() //$NON-NLS-1$
+								+ EMAIL_TEXT + devel.getEmail() //$NON-NLS-1$
 								+ "]"); //$NON-NLS-1$
 					}
 					return devel;
@@ -224,7 +226,7 @@ public final class ExtendedArtifact implements Artifact {
 					logger.debug(
 							"Comparing '" + login //$NON-NLS-1$
 							+ " to the contributor [NAME=" + contrib.getName() //$NON-NLS-1$
-							+ ";EMAIL=" + contrib.getEmail() //$NON-NLS-1$
+							+ EMAIL_TEXT + contrib.getEmail() //$NON-NLS-1$
 							+ "]"); //$NON-NLS-1$
 				}
 				String idprop = null;
@@ -241,7 +243,7 @@ public final class ExtendedArtifact implements Artifact {
 					if (logger != null && logger.isDebugEnabled()) {
 						logger.debug(
 								"Selecting the contributor [NAME=" + contrib.getName() //$NON-NLS-1$
-								+ ";EMAIL=" + contrib.getEmail() //$NON-NLS-1$
+								+ EMAIL_TEXT + contrib.getEmail() //$NON-NLS-1$
 								+ "]"); //$NON-NLS-1$
 					}
 					return contrib;


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1192 - “String literals should not be duplicated”. 
This PR will reduce 120 min TD.
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1192
 Please let me know if you have any questions.
Fevzi Ozgul