### PR TITLE
Fixing squid: S1168 Empty arrays and collections should be returned instead of null

### DIFF
--- a/advanced/attributes/src/main/java/org/arakhne/afc/attrs/attr/AttributeValueImpl.java
+++ b/advanced/attributes/src/main/java/org/arakhne/afc/attrs/attr/AttributeValueImpl.java
@@ -2258,7 +2258,7 @@ public class AttributeValueImpl implements AttributeValue {
 	private static Point2D<?, ?>[] parsePolyline(String text, boolean isStrict) {
 		final String[] comp = text.split(";"); //$NON-NLS-1$
 		if (isStrict && (comp.length % 2) != 0) {
-			return new Point2D<?,?>[0];
+			return new Point2D<?, ?>[0];
 		}
 		final int fullPoints = comp.length / 2;
 		final boolean addPt = fullPoints * 2 != comp.length;

--- a/advanced/attributes/src/main/java/org/arakhne/afc/attrs/attr/AttributeValueImpl.java
+++ b/advanced/attributes/src/main/java/org/arakhne/afc/attrs/attr/AttributeValueImpl.java
@@ -2092,7 +2092,7 @@ public class AttributeValueImpl implements AttributeValue {
 	private static Point3D[] parsePolyline3D(String text, boolean isStrict) {
 		final String[] comp = text.split(";"); //$NON-NLS-1$
 		if (isStrict && (comp.length % 3) != 0) {
-			return null;
+			return new Point3D[0];
 		}
 		final int fullPoints = comp.length / 3;
 		final boolean addPt = fullPoints * 3 != comp.length;
@@ -2258,7 +2258,7 @@ public class AttributeValueImpl implements AttributeValue {
 	private static Point2D<?, ?>[] parsePolyline(String text, boolean isStrict) {
 		final String[] comp = text.split(";"); //$NON-NLS-1$
 		if (isStrict && (comp.length % 2) != 0) {
-			return null;
+			return new Point2D<?,?>[0];
 		}
 		final int fullPoints = comp.length / 2;
 		final boolean addPt = fullPoints * 2 != comp.length;

--- a/core/math/src/main/java/org/arakhne/afc/math/tree/node/AbstractParentlessTreeNode.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/tree/node/AbstractParentlessTreeNode.java
@@ -21,7 +21,6 @@
 package org.arakhne.afc.math.tree.node;
 
 import java.io.Serializable;
-import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -248,7 +247,7 @@ public abstract class AbstractParentlessTreeNode<D, N extends AbstractParentless
 	@Override
 	public D[] getAllUserData(D[] array) {
 		if (this.data == null) {
-			return  (D[]) Array.newInstance(array.getClass(),0);
+			return null;
 		}
 		return this.data.toArray(array);
 	}

--- a/core/math/src/main/java/org/arakhne/afc/math/tree/node/AbstractParentlessTreeNode.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/tree/node/AbstractParentlessTreeNode.java
@@ -21,6 +21,7 @@
 package org.arakhne.afc.math.tree.node;
 
 import java.io.Serializable;
+import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -247,7 +248,7 @@ public abstract class AbstractParentlessTreeNode<D, N extends AbstractParentless
 	@Override
 	public D[] getAllUserData(D[] array) {
 		if (this.data == null) {
-			return null;
+			return  (D[]) Array.newInstance(array.getClass(),0);
 		}
 		return this.data.toArray(array);
 	}

--- a/core/vmutils/src/main/java/org/arakhne/afc/vmutil/MACNumber.java
+++ b/core/vmutils/src/main/java/org/arakhne/afc/vmutil/MACNumber.java
@@ -23,12 +23,7 @@ package org.arakhne.afc.vmutil;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
 import java.net.SocketException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.regex.Pattern;
 
 import org.eclipse.xtext.xbase.lib.Pure;
@@ -320,7 +315,7 @@ public final class MACNumber {
 		} catch (SocketException exception) {
 			//
 		}
-		return null;
+		return Collections.emptyList();
 	}
 
 	@Override

--- a/core/vmutils/src/main/java/org/arakhne/afc/vmutil/MACNumber.java
+++ b/core/vmutils/src/main/java/org/arakhne/afc/vmutil/MACNumber.java
@@ -23,7 +23,13 @@ package org.arakhne.afc.vmutil;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
 import java.net.SocketException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.regex.Pattern;
 
 import org.eclipse.xtext.xbase.lib.Pure;

--- a/core/vmutils/src/main/java/org/arakhne/afc/vmutil/VMCommandLine.java
+++ b/core/vmutils/src/main/java/org/arakhne/afc/vmutil/VMCommandLine.java
@@ -480,7 +480,7 @@ public class VMCommandLine {
 			final List<Object> value = commandLineOptions.get(name);
 			return value == null ? Collections.emptyList() : value;
 		}
-		return null;
+		return Collections.emptyList();
 	}
 
 	/** Replies if an option was specified on the command line.
@@ -836,7 +836,7 @@ public class VMCommandLine {
 	public List<Object> getOptionValues(String optionLabel) {
 		final List<Object> options = getCommandLineOption(optionLabel);
 		if (options == null) {
-			return null;
+			return Collections.emptyList();
 		}
 		return Collections.unmodifiableList(options);
 	}

--- a/core/vmutils/src/main/java/org/arakhne/afc/vmutil/file/URLConnection.java
+++ b/core/vmutils/src/main/java/org/arakhne/afc/vmutil/file/URLConnection.java
@@ -38,6 +38,7 @@ import java.util.Map;
 
 import javax.activation.MimetypesFileTypeMap;
 
+import com.sun.xml.internal.ws.policy.privateutil.PolicyUtils;
 import org.arakhne.afc.vmutil.FileSystem;
 import org.arakhne.afc.vmutil.asserts.AssertMessages;
 import org.arakhne.afc.vmutil.locale.Locale;
@@ -149,7 +150,7 @@ class URLConnection extends java.net.URLConnection {
 
 	private static List<String> singletonList(String value) {
 		if (value == null) {
-			return null;
+			return Collections.emptyList();
 		}
 		return Collections.singletonList(value);
 	}

--- a/core/vmutils/src/main/java/org/arakhne/afc/vmutil/file/URLConnection.java
+++ b/core/vmutils/src/main/java/org/arakhne/afc/vmutil/file/URLConnection.java
@@ -38,7 +38,6 @@ import java.util.Map;
 
 import javax.activation.MimetypesFileTypeMap;
 
-import com.sun.xml.internal.ws.policy.privateutil.PolicyUtils;
 import org.arakhne.afc.vmutil.FileSystem;
 import org.arakhne.afc.vmutil.asserts.AssertMessages;
 import org.arakhne.afc.vmutil.locale.Locale;

--- a/core/vmutils/src/test/java/org/arakhne/afc/vmutil/VMCommandLineTest.java
+++ b/core/vmutils/src/test/java/org/arakhne/afc/vmutil/VMCommandLineTest.java
@@ -158,9 +158,9 @@ public class VMCommandLineTest {
 		values = VMCommandLine.getCommandLineOption("S"); 
 		assertNotNull(values);
 		assertEquals(1, values.size());
-		assertEquals("-b", values.get(0)); 
+		assertEquals("-b", values.get(0));
 
-		assertNull(VMCommandLine.getCommandLineOption("nob")); 
+		assertEquals(new ArrayList<>(0), VMCommandLine.getCommandLineOption("nob"));
 	}
 
 	@Test

--- a/core/vmutils/src/test/java/org/arakhne/afc/vmutil/VMCommandLineTest.java
+++ b/core/vmutils/src/test/java/org/arakhne/afc/vmutil/VMCommandLineTest.java
@@ -29,6 +29,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -149,8 +150,7 @@ public class VMCommandLineTest {
 
 	@Test
 	public void getCommandLineOption() {
-		assertNull(VMCommandLine.getCommandLineOption("S")); 
-		
+		assertEquals(new ArrayList<>(0), VMCommandLine.getCommandLineOption("S"));
 		VMCommandLine.saveVMParameters(VMCommandLineTest.class, commandLine);
 		VMCommandLine.splitOptionsAndParameters(optionDefinitions);
 		
@@ -209,7 +209,7 @@ public class VMCommandLineTest {
 	public void getOptionValues() {
 		VMCommandLine c = new VMCommandLine(VMCommandLineTest.class, optionDefinitions, commandLine);
 		List<Object> values;
-		
+
 		values = c.getOptionValues("D"); 
 		assertNotNull(values);
 		assertEquals(1, values.size());
@@ -234,9 +234,9 @@ public class VMCommandLineTest {
 		values = c.getOptionValues("S"); 
 		assertNotNull(values);
 		assertEquals(1, values.size());
-		assertEquals("-b", values.get(0)); 
+		assertEquals("-b", values.get(0));
+		assertEquals(new ArrayList<>(0), c.getOptionValues("nob"));
 
-		assertNull(c.getOptionValues("nob")); 
 	}
 
 	@Test


### PR DESCRIPTION
  This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1168- “ Empty arrays and collections should be returned instead of null”. 
 You can find more information about the issues here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1168
 Please let me know if you have any questions.
Fevzi Ozgul