### PR TITLE
Fixing squid: S1854 Dead stores should be removed part 2

### DIFF
--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/ai/Path2ai.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/ai/Path2ai.java
@@ -2005,7 +2005,7 @@ public interface Path2ai<
         while (pi.hasNext()) {
             pe = pi.next();
 
-            boolean foundCandidate = false;
+            final boolean foundCandidate;
             final int candidateX;
             final int candidateY;
 
@@ -2840,7 +2840,7 @@ public interface Path2ai<
             if (this.typeIndex >= this.path.getPathElementCount()) {
                 throw new NoSuchElementException();
             }
-            E element = null;
+            final E element;
             switch (this.path.getPathElementTypeAt(type)) {
             case MOVE_TO:
                 if ((this.coordIndex + 2) > (this.path.size() * 2)) {
@@ -2977,7 +2977,7 @@ public interface Path2ai<
             if (this.typeIndex >= this.path.getPathElementCount()) {
                 throw new NoSuchElementException();
             }
-            E element = null;
+            final E element;
             switch (this.path.getPathElementTypeAt(this.typeIndex++)) {
             case MOVE_TO:
                 this.movex = this.path.getCoordAt(this.coordIndex++);


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1854 - “ Dead stores should be removed ”. 
This PR will remove 45 min of TD.
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1854
 Please let me know if you have any questions.
Fevzi Ozgul