### PR TITLE
Fixing squid: S1854 Dead stores should be removed part 4

### DIFF
--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d3/ai/Path3ai.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d3/ai/Path3ai.java
@@ -1598,8 +1598,7 @@ public interface Path3ai<
 
 		while (pi.hasNext()) {
 			pe = pi.next();
-
-			final boolean foundCandidate;
+            boolean foundCandidate = false;
 			final int candidateX;
 			final int candidateY;
 			final int candidateZ;

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d3/ai/Path3ai.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d3/ai/Path3ai.java
@@ -1599,7 +1599,7 @@ public interface Path3ai<
 		while (pi.hasNext()) {
 			pe = pi.next();
 
-			boolean foundCandidate;
+			final boolean foundCandidate;
 			final int candidateX;
 			final int candidateY;
 			final int candidateZ;

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d3/ai/Path3ai.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d3/ai/Path3ai.java
@@ -1599,7 +1599,7 @@ public interface Path3ai<
 		while (pi.hasNext()) {
 			pe = pi.next();
 
-			boolean foundCandidate = false;
+			boolean foundCandidate;
 			final int candidateX;
 			final int candidateY;
 			final int candidateZ;

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d3/ai/PathShadow3ai.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d3/ai/PathShadow3ai.java
@@ -282,8 +282,6 @@ public class PathShadow3ai<B extends RectangularPrism3ai<?, ?, ?, ?, ?, B>> {
 		final int shadowXmax = Math.max(shadow_x0, shadow_x1);
 		final int shadowYmin = Math.min(shadow_y0, shadow_y1);
 		final int shadowYmax = Math.max(shadow_y0, shadow_y1);
-		final int shadowZmin = Math.min(shadow_z0, shadow_z1);
-		final int shadowZmax = Math.max(shadow_z0, shadow_z1);
 
 		data.updateShadowLimits(shadow_x0, shadow_y0, shadow_z0, shadow_x1, shadow_y1, shadow_z1);
 

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d3/ai/PathShadow3ai.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d3/ai/PathShadow3ai.java
@@ -282,7 +282,7 @@ public class PathShadow3ai<B extends RectangularPrism3ai<?, ?, ?, ?, ?, B>> {
 		final int shadowXmax = Math.max(shadow_x0, shadow_x1);
 		final int shadowYmin = Math.min(shadow_y0, shadow_y1);
 		final int shadowYmax = Math.max(shadow_y0, shadow_y1);
-
+		final int shadowZmin = Math.min(shadow_z0, shadow_z1);
 		data.updateShadowLimits(shadow_x0, shadow_y0, shadow_z0, shadow_x1, shadow_y1, shadow_z1);
 
         if (sy0 < shadowYmin && sy1 < shadowYmin) {

--- a/core/references/src/main/java/org/arakhne/afc/references/AbstractReferencedSet.java
+++ b/core/references/src/main/java/org/arakhne/afc/references/AbstractReferencedSet.java
@@ -141,8 +141,7 @@ public abstract class AbstractReferencedSet<E, R extends Reference<E>> extends A
 				reference.enqueue();
 				reference.clear();
 			}
-		}
-		reference = null;
+		};
 
 		while ((obj = this.queue.poll()) != null) {
 			obj.clear();

--- a/core/references/src/main/java/org/arakhne/afc/references/AbstractReferencedSet.java
+++ b/core/references/src/main/java/org/arakhne/afc/references/AbstractReferencedSet.java
@@ -141,7 +141,7 @@ public abstract class AbstractReferencedSet<E, R extends Reference<E>> extends A
 				reference.enqueue();
 				reference.clear();
 			}
-		};
+		}
 
 		while ((obj = this.queue.poll()) != null) {
 			obj.clear();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1854 - “ Dead stores should be removed ”. 
This PR will remove 60 min of TD.
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1854
 Please let me know if you have any questions.
Fevzi Ozgul