### PR TITLE
Fixing squid : S1602 Lamdbas containing only one statement should not nest this statement in a block  part 1

### DIFF
--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/AbstractRectangularShape2dfx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/AbstractRectangularShape2dfx.java
@@ -326,12 +326,11 @@ public abstract class AbstractRectangularShape2dfx<IT extends AbstractRectangula
 	public ObjectProperty<Rectangle2dfx> boundingBoxProperty() {
 		if (this.boundingBox == null) {
 			this.boundingBox = new SimpleObjectProperty<>(this, MathFXAttributeNames.BOUNDING_BOX);
-			this.boundingBox.bind(Bindings.createObjectBinding(() -> {
-				return toBoundingBox();
-			},
+			this.boundingBox.bind(Bindings.createObjectBinding(() ->  toBoundingBox(),
 				minXProperty(), minYProperty(), widthProperty(), heightProperty()));
 		}
 		return this.boundingBox;
 	}
 
 }
+

--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/Circle2dfx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/Circle2dfx.java
@@ -222,9 +222,7 @@ public class Circle2dfx
 	public ObjectProperty<Rectangle2dfx> boundingBoxProperty() {
 		if (this.boundingBox == null) {
 			this.boundingBox = new SimpleObjectProperty<>(this, MathFXAttributeNames.BOUNDING_BOX);
-			this.boundingBox.bind(Bindings.createObjectBinding(() -> {
-				return toBoundingBox();
-			},
+			this.boundingBox.bind(Bindings.createObjectBinding(() ->  toBoundingBox(),
 					xProperty(), yProperty(), radiusProperty()));
 		}
 		return this.boundingBox;

--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/OrientedPoint2dfx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/OrientedPoint2dfx.java
@@ -384,9 +384,7 @@ public class OrientedPoint2dfx
     public ObjectProperty<Rectangle2dfx> boundingBoxProperty() {
         if (this.boundingBox == null) {
             this.boundingBox = new SimpleObjectProperty<>(this, MathFXAttributeNames.BOUNDING_BOX);
-            this.boundingBox.bind(Bindings.createObjectBinding(() -> {
-                return toBoundingBox();
-            }, this.dx, this.dy, this.px, this.py));
+            this.boundingBox.bind(Bindings.createObjectBinding(() -> toBoundingBox(), this.dx, this.dy, this.px, this.py));
         }
         return this.boundingBox;
     }

--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/OrientedRectangle2dfx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/OrientedRectangle2dfx.java
@@ -427,9 +427,7 @@ public class OrientedRectangle2dfx extends AbstractShape2dfx<OrientedRectangle2d
 	public ObjectProperty<Rectangle2dfx> boundingBoxProperty() {
 		if (this.boundingBox == null) {
 			this.boundingBox = new SimpleObjectProperty<>(this, MathFXAttributeNames.BOUNDING_BOX);
-			this.boundingBox.bind(Bindings.createObjectBinding(() -> {
-				return toBoundingBox();
-			},
+			this.boundingBox.bind(Bindings.createObjectBinding(() -> toBoundingBox(),
 				centerXProperty(), centerYProperty(),
 				firstAxisProperty(), firstAxisExtentProperty(),
 				secondAxisExtentProperty()));

--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/Parallelogram2dfx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/Parallelogram2dfx.java
@@ -429,9 +429,7 @@ public class Parallelogram2dfx extends AbstractShape2dfx<Parallelogram2dfx>
 	public ObjectProperty<Rectangle2dfx> boundingBoxProperty() {
 		if (this.boundingBox == null) {
 			this.boundingBox = new SimpleObjectProperty<>(this, MathFXAttributeNames.BOUNDING_BOX);
-			this.boundingBox.bind(Bindings.createObjectBinding(() -> {
-				return toBoundingBox();
-			},
+			this.boundingBox.bind(Bindings.createObjectBinding(() -> toBoundingBox(),
 					centerXProperty(), centerYProperty(),
 					firstAxisProperty(), firstAxisExtentProperty(),
 					secondAxisProperty(), secondAxisExtentProperty()));

--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/Path2dfx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/Path2dfx.java
@@ -853,9 +853,7 @@ public class Path2dfx extends AbstractShape2dfx<Path2dfx>
 	public DoubleProperty lengthProperty() {
 		if (this.length == null) {
 			this.length = new ReadOnlyDoubleWrapper();
-			this.length.bind(Bindings.createDoubleBinding(() -> {
-				return Path2afp.calculatesPathLength(getPathIterator());
-			},
+            this.length.bind(Bindings.createDoubleBinding(() -> Path2afp.calculatesPathLength(getPathIterator()),
 					innerTypesProperty(), innerCoordinatesProperty()));
 		}
 		return this.length;


### PR DESCRIPTION
"This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1602 - “Lamdbas containing only one statement should not nest this statement”. 
This PR will remove 30 min of TD.
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1602
 Please let me know if you have any questions.
Fevzi Ozgul