### PR TITLE
Fixing squid: S1602 Lamdbas containing only one statement should not nest this statement in a block part 4

### DIFF
--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/ifx/Segment2ifx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/ifx/Segment2ifx.java
@@ -261,9 +261,7 @@ public class Segment2ifx extends AbstractShape2ifx<Segment2ifx>
 	public ObjectProperty<Rectangle2ifx> boundingBoxProperty() {
 		if (this.boundingBox == null) {
 			this.boundingBox = new SimpleObjectProperty<>(this, MathFXAttributeNames.BOUNDING_BOX);
-			this.boundingBox.bind(Bindings.createObjectBinding(() -> {
-				return toBoundingBox();
-			},
+			this.boundingBox.bind(Bindings.createObjectBinding(() -> toBoundingBox(),
 					x1Property(), y1Property(),
 					x2Property(), y2Property()));
 		}

--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/ifx/Vector2ifx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/ifx/Vector2ifx.java
@@ -152,9 +152,8 @@ public class Vector2ifx extends Tuple2ifx<Vector2ifx> implements Vector2D<Vector
 	public DoubleProperty lengthProperty() {
 		if (this.lengthProperty == null) {
 			this.lengthProperty = new ReadOnlyDoubleWrapper(this, MathFXAttributeNames.LENGTH);
-			this.lengthProperty.bind(Bindings.createDoubleBinding(() -> {
-				return Math.sqrt(lengthSquaredProperty().doubleValue());
-			}, lengthSquaredProperty()));
+			this.lengthProperty.bind(Bindings.createDoubleBinding(() ->
+				Math.sqrt(lengthSquaredProperty().doubleValue()), lengthSquaredProperty()));
 		}
 		return this.lengthProperty;
 	}

--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d3/dfx/Path3dfx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d3/dfx/Path3dfx.java
@@ -880,9 +880,8 @@ public class Path3dfx
 	public DoubleProperty lengthProperty() {
 	    if (this.length == null) {
 	        this.length = new ReadOnlyDoubleWrapper();
-	        this.length.bind(Bindings.createDoubleBinding(() -> {
-	            return Path3afp.computeLength(getPathIterator());
-	        },
+	        this.length.bind(Bindings.createDoubleBinding(() ->
+	            Path3afp.computeLength(getPathIterator()),
 	                innerTypesProperty(), innerCoordinatesProperty()));
 	    }
 		return this.length;

--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d3/dfx/PathElement3dfx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d3/dfx/PathElement3dfx.java
@@ -525,11 +525,11 @@ public abstract class PathElement3dfx implements PathElement3afp {
 		public BooleanProperty isEmptyProperty() {
 			if (this.isEmpty == null) {
 				this.isEmpty = new ReadOnlyBooleanWrapper(this, "isEmpty"); //$NON-NLS-1$
-				this.isEmpty.bind(Bindings.createBooleanBinding(() -> {
-				    return MathUtil.isEpsilonEqual(fromXProperty().get(), toXProperty().get())
+				this.isEmpty.bind(Bindings.createBooleanBinding(() ->
+				    MathUtil.isEpsilonEqual(fromXProperty().get(), toXProperty().get())
 				            && MathUtil.isEpsilonEqual(fromYProperty().get(), toYProperty().get())
-				            && MathUtil.isEpsilonEqual(fromZProperty().get(), toZProperty().get());
-				}, fromXProperty(), toXProperty(), fromYProperty(), toYProperty(), fromZProperty(), toZProperty()));
+				            && MathUtil.isEpsilonEqual(fromZProperty().get(), toZProperty().get()),
+						fromXProperty(), toXProperty(), fromYProperty(), toYProperty(), fromZProperty(), toZProperty()));
 			}
 			return this.isEmpty;
 		}
@@ -795,14 +795,14 @@ public abstract class PathElement3dfx implements PathElement3afp {
 		public BooleanProperty isEmptyProperty() {
 			if (this.isEmpty == null) {
 				this.isEmpty = new ReadOnlyBooleanWrapper(this, "isEmpty"); //$NON-NLS-1$
-				this.isEmpty.bind(Bindings.createBooleanBinding(() -> {
-				    return MathUtil.isEpsilonEqual(fromXProperty().get(), toXProperty().get())
+				this.isEmpty.bind(Bindings.createBooleanBinding(() ->
+				    MathUtil.isEpsilonEqual(fromXProperty().get(), toXProperty().get())
 				            && MathUtil.isEpsilonEqual(fromYProperty().get(), toYProperty().get())
 				            && MathUtil.isEpsilonEqual(fromZProperty().get(), toZProperty().get())
 				            && MathUtil.isEpsilonEqual(ctrlX1Property().get(), toXProperty().get())
 				            && MathUtil.isEpsilonEqual(ctrlY1Property().get(), toYProperty().get())
-				            && MathUtil.isEpsilonEqual(ctrlZ1Property().get(), toZProperty().get());
-				}, fromXProperty(), toXProperty(), fromYProperty(), toYProperty(), fromZProperty(), toZProperty()));
+				            && MathUtil.isEpsilonEqual(ctrlZ1Property().get(), toZProperty().get()),
+						fromXProperty(), toXProperty(), fromYProperty(), toYProperty(), fromZProperty(), toZProperty()));
 			}
 			return this.isEmpty;
 		}
@@ -1104,8 +1104,8 @@ public abstract class PathElement3dfx implements PathElement3afp {
 		public BooleanProperty isEmptyProperty() {
 			if (this.isEmpty == null) {
 				this.isEmpty = new ReadOnlyBooleanWrapper(this, "isEmpty"); //$NON-NLS-1$
-				this.isEmpty.bind(Bindings.createBooleanBinding(() -> {
-				    return MathUtil.isEpsilonEqual(fromXProperty().get(), toXProperty().get())
+				this.isEmpty.bind(Bindings.createBooleanBinding(() ->
+				    MathUtil.isEpsilonEqual(fromXProperty().get(), toXProperty().get())
 				            && MathUtil.isEpsilonEqual(fromYProperty().get(), toYProperty().get())
 				            && MathUtil.isEpsilonEqual(fromZProperty().get(), toZProperty().get())
 				            && MathUtil.isEpsilonEqual(ctrlX1Property().get(), toXProperty().get())
@@ -1113,8 +1113,8 @@ public abstract class PathElement3dfx implements PathElement3afp {
 				            && MathUtil.isEpsilonEqual(ctrlZ1Property().get(), toZProperty().get())
 				            && MathUtil.isEpsilonEqual(ctrlX2Property().get(), toXProperty().get())
 				            && MathUtil.isEpsilonEqual(ctrlY2Property().get(), toYProperty().get())
-				            && MathUtil.isEpsilonEqual(ctrlZ2Property().get(), toZProperty().get());
-				}, fromXProperty(), toXProperty(), fromYProperty(), toYProperty(), fromZProperty(), toZProperty()));
+				            && MathUtil.isEpsilonEqual(ctrlZ2Property().get(), toZProperty().get()),
+						fromXProperty(), toXProperty(), fromYProperty(), toYProperty(), fromZProperty(), toZProperty()));
 			}
 			return this.isEmpty;
 		}
@@ -1384,11 +1384,11 @@ public abstract class PathElement3dfx implements PathElement3afp {
 		public BooleanProperty isEmptyProperty() {
 			if (this.isEmpty == null) {
 				this.isEmpty = new ReadOnlyBooleanWrapper(this, "isEmpty"); //$NON-NLS-1$
-				this.isEmpty.bind(Bindings.createBooleanBinding(() -> {
-				    return MathUtil.isEpsilonEqual(fromXProperty().get(), toXProperty().get())
+				this.isEmpty.bind(Bindings.createBooleanBinding(() ->
+				    MathUtil.isEpsilonEqual(fromXProperty().get(), toXProperty().get())
 				            && MathUtil.isEpsilonEqual(fromYProperty().get(), toYProperty().get())
-				            && MathUtil.isEpsilonEqual(fromZProperty().get(), toZProperty().get());
-				}, fromXProperty(), toXProperty(), fromYProperty(), toYProperty(), fromZProperty(), toZProperty()));
+				            && MathUtil.isEpsilonEqual(fromZProperty().get(), toZProperty().get()),
+						fromXProperty(), toXProperty(), fromYProperty(), toYProperty(), fromZProperty(), toZProperty()));
 			}
 			return this.isEmpty;
 		}

--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d3/dfx/RectangularPrism3dfx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d3/dfx/RectangularPrism3dfx.java
@@ -455,9 +455,8 @@ public class RectangularPrism3dfx extends AbstractShape3dfx<RectangularPrism3dfx
 	public ObjectProperty<RectangularPrism3dfx> boundingBoxProperty() {
 		if (this.boundingBox == null) {
 			this.boundingBox = new SimpleObjectProperty<>(this, "boundingBox"); //$NON-NLS-1$
-			this.boundingBox.bind(Bindings.createObjectBinding(() -> {
-			    return toBoundingBox();
-			},
+			this.boundingBox.bind(Bindings.createObjectBinding(() ->
+			    toBoundingBox(),
 			        minXProperty(), minYProperty(), minZProperty(), widthProperty(), heightProperty(), depthProperty()));
 		}
 		return this.boundingBox;


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
squid:S1602 - “Lamdbas containing only one statement should not nest this statement”. 
This PR will remove 50 min of TD.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1602
Please let me know if you have any questions.
Fevzi Ozgul