### PR TITLE
Fixing squid: S1602 Lamdbas containing only one statement should not nest this statement in a block part 5 final

### DIFF
--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d3/dfx/Segment3dfx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d3/dfx/Segment3dfx.java
@@ -330,9 +330,7 @@ public class Segment3dfx extends AbstractShape3dfx<Segment3dfx>
 	public ObjectProperty<RectangularPrism3dfx> boundingBoxProperty() {
 		if (this.boundingBox == null) {
 			this.boundingBox = new SimpleObjectProperty<>(this, "boundingBox"); //$NON-NLS-1$
-			this.boundingBox.bind(Bindings.createObjectBinding(() -> {
-			    return toBoundingBox();
-			},
+			this.boundingBox.bind(Bindings.createObjectBinding(() -> toBoundingBox(),
 			        x1Property(), y1Property(), z1Property(),
 			        x2Property(), y2Property(), z2Property()));
 		}

--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d3/dfx/Sphere3dfx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d3/dfx/Sphere3dfx.java
@@ -256,9 +256,8 @@ public class Sphere3dfx
 	public ObjectProperty<RectangularPrism3dfx> boundingBoxProperty() {
 		if (this.boundingBox == null) {
 			this.boundingBox = new SimpleObjectProperty<>(this, "boundingBox"); //$NON-NLS-1$
-			this.boundingBox.bind(Bindings.createObjectBinding(() -> {
-			    return toBoundingBox();
-			},
+			this.boundingBox.bind(Bindings.createObjectBinding(() ->
+			    toBoundingBox(),
 			        xProperty(), yProperty(), zProperty(), radiusProperty()));
 		}
 		return this.boundingBox;

--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d3/dfx/Vector3dfx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d3/dfx/Vector3dfx.java
@@ -145,9 +145,8 @@ public class Vector3dfx extends Tuple3dfx<Vector3dfx> implements Vector3D<Vector
 	public ReadOnlyDoubleProperty lengthProperty() {
 		if (this.lengthProperty == null) {
 			this.lengthProperty = new ReadOnlyDoubleWrapper(this, "length"); //$NON-NLS-1$
-			this.lengthProperty.bind(Bindings.createDoubleBinding(() -> {
-			    return Math.sqrt(lengthSquaredProperty().doubleValue());
-			}, lengthSquaredProperty()));
+			this.lengthProperty.bind(Bindings.createDoubleBinding(() ->
+			    Math.sqrt(lengthSquaredProperty().doubleValue()), lengthSquaredProperty()));
 		}
 		return this.lengthProperty.getReadOnlyProperty();
 	}
@@ -164,11 +163,10 @@ public class Vector3dfx extends Tuple3dfx<Vector3dfx> implements Vector3D<Vector
 	public ReadOnlyDoubleProperty lengthSquaredProperty() {
 		if (this.lengthSquareProperty == null) {
 			this.lengthSquareProperty = new ReadOnlyDoubleWrapper(this, "lengthSquared"); //$NON-NLS-1$
-			this.lengthSquareProperty.bind(Bindings.createDoubleBinding(() -> {
-			    return Vector3dfx.this.x.doubleValue() * Vector3dfx.this.x.doubleValue()
+			this.lengthSquareProperty.bind(Bindings.createDoubleBinding(() ->
+			    Vector3dfx.this.x.doubleValue() * Vector3dfx.this.x.doubleValue()
 			            + Vector3dfx.this.y.doubleValue() * Vector3dfx.this.y.doubleValue()
-			            + Vector3dfx.this.z.doubleValue() * Vector3dfx.this.z.doubleValue();
-			}, this.x, this.y, this.z));
+			            + Vector3dfx.this.z.doubleValue() * Vector3dfx.this.z.doubleValue(), this.x, this.y, this.z));
 		}
 		return this.lengthSquareProperty.getReadOnlyProperty();
 	}

--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d3/ifx/AbstractRectangularShape3ifx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d3/ifx/AbstractRectangularShape3ifx.java
@@ -433,9 +433,8 @@ public abstract class AbstractRectangularShape3ifx<IT extends AbstractRectangula
 	public ObjectProperty<RectangularPrism3ifx> boundingBoxProperty() {
 		if (this.boundingBox == null) {
 			this.boundingBox = new SimpleObjectProperty<>(this, "boundingBox"); //$NON-NLS-1$
-			this.boundingBox.bind(Bindings.createObjectBinding(() -> {
-			    return toBoundingBox();
-			},
+			this.boundingBox.bind(Bindings.createObjectBinding(() ->
+			    toBoundingBox(),
 			        minXProperty(), minYProperty(), widthProperty(), heightProperty()));
 		}
 		return this.boundingBox;

--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d3/ifx/RectangularPrism3ifx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d3/ifx/RectangularPrism3ifx.java
@@ -445,9 +445,8 @@ public class RectangularPrism3ifx extends AbstractShape3ifx<RectangularPrism3ifx
 	public ObjectProperty<RectangularPrism3ifx> boundingBoxProperty() {
 		if (this.boundingBox == null) {
 			this.boundingBox = new SimpleObjectProperty<>(this, "boundingBox"); //$NON-NLS-1$
-			this.boundingBox.bind(Bindings.createObjectBinding(() -> {
-			    return toBoundingBox();
-			},
+			this.boundingBox.bind(Bindings.createObjectBinding(() ->
+			    toBoundingBox(),
 			        minXProperty(), minYProperty(), widthProperty(), heightProperty()));
 		}
 		return this.boundingBox;

--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d3/ifx/Segment3ifx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d3/ifx/Segment3ifx.java
@@ -329,9 +329,8 @@ public class Segment3ifx extends AbstractShape3ifx<Segment3ifx>
 	public ObjectProperty<RectangularPrism3ifx> boundingBoxProperty() {
 		if (this.boundingBox == null) {
 			this.boundingBox = new SimpleObjectProperty<>(this, "boundingBox"); //$NON-NLS-1$
-			this.boundingBox.bind(Bindings.createObjectBinding(() -> {
-			    return toBoundingBox();
-			},
+			this.boundingBox.bind(Bindings.createObjectBinding(() ->
+			    toBoundingBox(),
 			        x1Property(), y1Property(), z1Property(),
 			        x2Property(), y2Property(), z2Property()));
 		}

--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d3/ifx/Sphere3ifx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d3/ifx/Sphere3ifx.java
@@ -247,9 +247,8 @@ public class Sphere3ifx
 	public ObjectProperty<RectangularPrism3ifx> boundingBoxProperty() {
 		if (this.boundingBox == null) {
 			this.boundingBox = new SimpleObjectProperty<>(this, "boundingBox"); //$NON-NLS-1$
-			this.boundingBox.bind(Bindings.createObjectBinding(() -> {
-			    return toBoundingBox();
-			},
+			this.boundingBox.bind(Bindings.createObjectBinding(() ->
+			   toBoundingBox(),
 			        xProperty(), yProperty(), zProperty(), radiusProperty()));
 		}
 		return this.boundingBox;

--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d3/ifx/Vector3ifx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d3/ifx/Vector3ifx.java
@@ -144,9 +144,8 @@ public class Vector3ifx extends Tuple3ifx<Vector3ifx> implements Vector3D<Vector
 	public DoubleProperty lengthProperty() {
 		if (this.lengthProperty == null) {
 			this.lengthProperty = new ReadOnlyDoubleWrapper(this, "length"); //$NON-NLS-1$
-			this.lengthProperty.bind(Bindings.createDoubleBinding(() -> {
-			    return Math.sqrt(lengthSquaredProperty().doubleValue());
-			}, lengthSquaredProperty()));
+			this.lengthProperty.bind(Bindings.createDoubleBinding(() ->
+			    Math.sqrt(lengthSquaredProperty().doubleValue()), lengthSquaredProperty()));
 		}
 		return this.lengthProperty;
 	}
@@ -163,11 +162,10 @@ public class Vector3ifx extends Tuple3ifx<Vector3ifx> implements Vector3D<Vector
 	public DoubleProperty lengthSquaredProperty() {
 		if (this.lengthSquareProperty == null) {
 			this.lengthSquareProperty = new ReadOnlyDoubleWrapper(this, "lengthSquared"); //$NON-NLS-1$
-			this.lengthSquareProperty.bind(Bindings.createDoubleBinding(() -> {
-			    return Vector3ifx.this.x.doubleValue() * Vector3ifx.this.x.doubleValue()
-			            + Vector3ifx.this.y.doubleValue() * Vector3ifx.this.y.doubleValue()
-			            + Vector3ifx.this.z.doubleValue() * Vector3ifx.this.z.doubleValue();
-			}, this.x, this.y, this.z));
+			this.lengthSquareProperty.bind(Bindings.createDoubleBinding(() ->
+					Vector3ifx.this.x.doubleValue() * Vector3ifx.this.x.doubleValue()
+							+ Vector3ifx.this.y.doubleValue() * Vector3ifx.this.y.doubleValue()
+							+ Vector3ifx.this.z.doubleValue() * Vector3ifx.this.z.doubleValue(), this.x, this.y, this.z));
 		}
 		return this.lengthSquareProperty;
 	}


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
squid:S1602 - “Lamdbas containing only one statement should not nest this statement”. 
This PR will remove 50 min of TD.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1602
Please let me know if you have any questions.
Fevzi Ozgul