### PR TITLE
Fixing squid:S1854 Dead stores should be removed part 6

### DIFF
--- a/core/references/src/main/java/org/arakhne/afc/references/AbstractReferencedSet.java
+++ b/core/references/src/main/java/org/arakhne/afc/references/AbstractReferencedSet.java
@@ -142,8 +142,6 @@ public abstract class AbstractReferencedSet<E, R extends Reference<E>> extends A
 				reference.clear();
 			}
 		}
-		reference = null;
-
 		while ((obj = this.queue.poll()) != null) {
 			obj.clear();
 			if (this.referenceType.isInstance(obj)) {

--- a/core/references/src/main/java/org/arakhne/afc/references/AbstractReferencedValueMap.java
+++ b/core/references/src/main/java/org/arakhne/afc/references/AbstractReferencedValueMap.java
@@ -213,8 +213,6 @@ public abstract class AbstractReferencedValueMap<K, V> extends AbstractMap<K, V>
 				}
 			}
 		}
-		entry = null;
-		value = null;
 		Reference<? extends V> reference;
 		while ((reference = this.queue.poll()) != null) {
 			if (reference instanceof ReferencableValue<?, ?>) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1854 - “ Dead stores should be removed ”. 
This PR will remove 45min of TD.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1854
Please let me know if you have any questions.
Fevzi Ozgul