### PR TITLE
Fixing squid: S1854 Dead stores should be removed part 7

### DIFF
--- a/core/text/src/main/java/org/arakhne/afc/text/TextUtil.java
+++ b/core/text/src/main/java/org/arakhne/afc/text/TextUtil.java
@@ -715,7 +715,7 @@ public final class TextUtil {
 			// inclusive
 			int startOffset = 0;
 			// exclusive
-			int endOffset = 0;
+			int endOffset;
 			int depth = 0;
 
 			final StringBuilder token = new StringBuilder();
@@ -1494,9 +1494,9 @@ public final class TextUtil {
 
 		final StringBuilder text = new StringBuilder();
 
-		String centuries = ""; //$NON-NLS-1$
-		String years = ""; //$NON-NLS-1$
-		String days = ""; //$NON-NLS-1$
+		final String centuries; //$NON-NLS-1$
+		final String years; //$NON-NLS-1$
+		final String days; //$NON-NLS-1$
 		String hours = ""; //$NON-NLS-1$
 		String minutes = ""; //$NON-NLS-1$
 		String seconds = ""; //$NON-NLS-1$


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1854 - “ Dead stores should be removed ”. 
This PR will remove 60min of TD.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1854
Please let me know if you have any questions.
Fevzi Ozgul