### PR TITLE
Fixing squid: S1854 Dead stores should be removed part 8

### DIFF
--- a/core/vmutils/src/main/java/org/arakhne/afc/vmutil/locale/Locale.java
+++ b/core/vmutils/src/main/java/org/arakhne/afc/vmutil/locale/Locale.java
@@ -431,7 +431,7 @@ public final class Locale {
 	 */
 	private static CharBuffer decodeString(byte[] bytes, Charset charset, int referenceLength) {
 		try {
-			Charset autodetectedCharset;
+			final Charset autodetectedCharset;
 			final CharsetDecoder decoder = charset.newDecoder();
 			final CharBuffer buffer = decoder.decode(ByteBuffer.wrap(bytes));
 			if ((decoder.isAutoDetecting())

--- a/core/vmutils/src/main/java/org/arakhne/afc/vmutil/locale/Locale.java
+++ b/core/vmutils/src/main/java/org/arakhne/afc/vmutil/locale/Locale.java
@@ -431,7 +431,7 @@ public final class Locale {
 	 */
 	private static CharBuffer decodeString(byte[] bytes, Charset charset, int referenceLength) {
 		try {
-			Charset autodetectedCharset = charset;
+			Charset autodetectedCharset;
 			final CharsetDecoder decoder = charset.newDecoder();
 			final CharBuffer buffer = decoder.decode(ByteBuffer.wrap(bytes));
 			if ((decoder.isAutoDetecting())
@@ -496,11 +496,10 @@ public final class Locale {
 		final byte[] buffer = new byte[BUFFER_SIZE];
 		int read;
 		while ((read = stream.read(buffer)) > 0) {
-			byte[] tmp = new byte[completeBuffer.length + read];
+			final byte[] tmp = new byte[completeBuffer.length + read];
 			System.arraycopy(completeBuffer, 0, tmp, 0, completeBuffer.length);
 			System.arraycopy(buffer, 0, tmp, completeBuffer.length, read);
 			completeBuffer = tmp;
-			tmp = null;
 		}
 		return decodeString(completeBuffer);
 	}
@@ -534,11 +533,10 @@ public final class Locale {
 		int read;
 
 		while ((read = stream.read(buffer)) > 0) {
-			byte[] tmp = new byte[completeBuffer.length + read];
+			final byte[] tmp = new byte[completeBuffer.length + read];
 			System.arraycopy(completeBuffer, 0, tmp, 0, completeBuffer.length);
 			System.arraycopy(buffer, 0, tmp, completeBuffer.length, read);
 			completeBuffer = tmp;
-			tmp = null;
 		}
 
 		// Get the two default charsets
@@ -563,13 +561,11 @@ public final class Locale {
 		if (!ok) {
 			for (final Entry<String, Charset> charset : Charset.availableCharsets().entrySet()) {
 				if (decodeString(new ByteArrayInputStream(completeBuffer), lineArray, charset.getValue())) {
-					completeBuffer = null;
 					return true;
 				}
 			}
 		}
 
-		completeBuffer = null;
 		return ok;
 	}
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1854 - “ Dead stores should be removed ”. 
This PR will remove 75min of TD.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1854
Please let me know if you have any questions.
Fevzi Ozgul