### PR TITLE
Fixing squid: S1609 @FunctionalInterface annotation should be used to flag Single Abstract Method interfaces

### DIFF
--- a/advanced/agentmotion/src/main/java/org/arakhne/afc/agentmotion/AligningMotionAlgorithm.java
+++ b/advanced/agentmotion/src/main/java/org/arakhne/afc/agentmotion/AligningMotionAlgorithm.java
@@ -32,6 +32,7 @@ import org.arakhne.afc.math.geometry.d2.Vector2D;
  * @mavenartifactid $ArtifactId$
  * @since 14.0
  */
+@FunctionalInterface
 public interface AligningMotionAlgorithm {
 
 	/** Calculate the rotation for being aligned to the target vector.

--- a/advanced/agentmotion/src/main/java/org/arakhne/afc/agentmotion/ArrivingMotionAlgorithm.java
+++ b/advanced/agentmotion/src/main/java/org/arakhne/afc/agentmotion/ArrivingMotionAlgorithm.java
@@ -33,6 +33,7 @@ import org.arakhne.afc.math.geometry.d2.Vector2D;
  * @mavenartifactid $ArtifactId$
  * @since 14.0
  */
+@FunctionalInterface
 public interface ArrivingMotionAlgorithm {
 
 	/** Calculate the linear motion for arriving the target point.

--- a/advanced/agentmotion/src/main/java/org/arakhne/afc/agentmotion/FacingMotionAlgorithm.java
+++ b/advanced/agentmotion/src/main/java/org/arakhne/afc/agentmotion/FacingMotionAlgorithm.java
@@ -33,6 +33,7 @@ import org.arakhne.afc.math.geometry.d2.Vector2D;
  * @mavenartifactid $ArtifactId$
  * @since 14.0
  */
+@FunctionalInterface
 public interface FacingMotionAlgorithm {
 
 	/** Calculate the rotation for facing the target point.

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/d/ShapeGeometryChangeListener.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/d/ShapeGeometryChangeListener.java
@@ -30,6 +30,7 @@ import java.util.EventListener;
  * @mavenartifactid $ArtifactId$
  * @since 13.0
  */
+@FunctionalInterface
 public interface ShapeGeometryChangeListener extends EventListener {
 
 	/** Invoked when the given shape has change of geometry.

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/i/ShapeGeometryChangeListener.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/i/ShapeGeometryChangeListener.java
@@ -30,6 +30,7 @@ import java.util.EventListener;
  * @mavenartifactid $ArtifactId$
  * @since 13.0
  */
+@FunctionalInterface
 public interface ShapeGeometryChangeListener extends EventListener {
 
 	/** Invoked when the given shape has change of geometry.

--- a/core/math/src/main/java/org/arakhne/afc/math/graph/astar/AStarHeuristic.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/graph/astar/AStarHeuristic.java
@@ -35,6 +35,7 @@ import org.arakhne.afc.math.graph.GraphPoint;
  * @since 13.0
  * @see AStar
  */
+@FunctionalInterface
 public interface AStarHeuristic<PT extends GraphPoint<PT, ?>> {
 
 	/** Evaluate the distance between two points in the graph.

--- a/core/math/src/main/java/org/arakhne/afc/math/tree/iterator/BroadFirstIterationListener.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/tree/iterator/BroadFirstIterationListener.java
@@ -31,6 +31,7 @@ import java.util.EventListener;
  * @mavenartifactid $ArtifactId$
  * @since 13.0
  */
+@FunctionalInterface
 public interface BroadFirstIterationListener extends EventListener {
 
 	/** Invoked when a row of tree nodes was completely replied by the iterator.

--- a/core/math/src/main/java/org/arakhne/afc/math/tree/iterator/DataSelector.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/tree/iterator/DataSelector.java
@@ -35,6 +35,7 @@ import org.eclipse.xtext.xbase.lib.Pure;
  * @see PostfixDataDepthFirstTreeIterator
  * @see DataBroadFirstTreeIterator
  */
+@FunctionalInterface
 public interface DataSelector<D> {
 
 	/** Replies if the specified data could be replied by the iterator.

--- a/core/math/src/main/java/org/arakhne/afc/math/tree/iterator/NodeSelector.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/tree/iterator/NodeSelector.java
@@ -37,6 +37,7 @@ import org.arakhne.afc.math.tree.TreeNode;
  * @see PostfixDataDepthFirstTreeIterator
  * @see DataBroadFirstTreeIterator
  */
+@FunctionalInterface
 public interface NodeSelector<N extends TreeNode<?, ?>> {
 
 	/** Replies if the specified node could be treated by the iterator.


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1609 - “@FunctionalInterface annotation should be used to flag Single Abstract Method interfaces”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1609
 Please let me know if you have any questions.
Fevzi Ozgul