### PR TITLE
Fixing squid: S1604 Anonymous inner classes containing only one method should become lambdas part 1

### DIFF
--- a/core/math/src/main/java/org/arakhne/afc/math/tree/AbstractTree.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/tree/AbstractTree.java
@@ -144,48 +144,48 @@ public abstract class AbstractTree<D, N extends TreeNode<D, N>>
 	@Pure
 	@Override
 	public final Iterable<N> toDepthFirstIterable() {
-		return () ->  AbstractTree.this.depthFirstIterator();
+		return () ->  this.depthFirstIterator();
 	}
 
 	@Pure
 	@Override
 	public final Iterable<N> toDepthFirstIterable(final DepthFirstNodeOrder nodeOrder) {
-		return () -> AbstractTree.this.depthFirstIterator(nodeOrder);
+		return () -> this.depthFirstIterator(nodeOrder);
 	}
 
 	@Override
 	@Pure
 	public final Iterable<N> toDepthFirstIterable(final int infixPosition) {
-		return () -> AbstractTree.this.depthFirstIterator(infixPosition);
+		return () -> this.depthFirstIterator(infixPosition);
 	}
 
 	@Pure
 	@Override
 	public final Iterable<N> toBroadFirstIterable() {
-		return () -> AbstractTree.this.broadFirstIterator();
+		return () -> this.broadFirstIterator();
 	}
 
 	@Override
 	@Pure
 	public final Iterable<D> toDataDepthFirstIterable() {
-		return () -> AbstractTree.this.dataDepthFirstIterator();
+		return () -> this.dataDepthFirstIterator();
 	}
 
 	@Override
 	@Pure
 	public final Iterable<D> toDataDepthFirstIterable(final DepthFirstNodeOrder nodeOrder) {
-		return () -> AbstractTree.this.dataDepthFirstIterator(nodeOrder);
+		return () -> this.dataDepthFirstIterator(nodeOrder);
 	}
 
 	@Override
 	@Pure
 	public final Iterable<D> toDataDepthFirstIterable(final int infixPosition) {
-		return () -> AbstractTree.this.dataDepthFirstIterator(infixPosition);
+		return () -> this.dataDepthFirstIterator(infixPosition);
 	}
 
 	@Pure
 	@Override
 	public final Iterable<D> toDataBroadFirstIterable() {
-		return () -> AbstractTree.this.dataBroadFirstIterator();
+		return () -> this.dataBroadFirstIterator();
 	}
 }

--- a/core/math/src/main/java/org/arakhne/afc/math/tree/AbstractTree.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/tree/AbstractTree.java
@@ -144,89 +144,48 @@ public abstract class AbstractTree<D, N extends TreeNode<D, N>>
 	@Pure
 	@Override
 	public final Iterable<N> toDepthFirstIterable() {
-		return new Iterable<N>() {
-			@Override
-			public Iterator<N> iterator() {
-				return AbstractTree.this.depthFirstIterator();
-			}
-		};
+		return () ->  AbstractTree.this.depthFirstIterator();
 	}
 
 	@Pure
 	@Override
 	public final Iterable<N> toDepthFirstIterable(final DepthFirstNodeOrder nodeOrder) {
-		return new Iterable<N>() {
-			@Override
-			public Iterator<N> iterator() {
-				return AbstractTree.this.depthFirstIterator(nodeOrder);
-			}
-		};
+		return () -> AbstractTree.this.depthFirstIterator(nodeOrder);
 	}
 
 	@Override
 	@Pure
 	public final Iterable<N> toDepthFirstIterable(final int infixPosition) {
-		return new Iterable<N>() {
-			@Override
-			public Iterator<N> iterator() {
-				return AbstractTree.this.depthFirstIterator(infixPosition);
-			}
-		};
+		return () -> AbstractTree.this.depthFirstIterator(infixPosition);
 	}
 
 	@Pure
 	@Override
 	public final Iterable<N> toBroadFirstIterable() {
-		return new Iterable<N>() {
-			@Override
-			public Iterator<N> iterator() {
-				return AbstractTree.this.broadFirstIterator();
-			}
-		};
+		return () -> AbstractTree.this.broadFirstIterator();
 	}
 
 	@Override
 	@Pure
 	public final Iterable<D> toDataDepthFirstIterable() {
-		return new Iterable<D>() {
-			@Override
-			public Iterator<D> iterator() {
-				return AbstractTree.this.dataDepthFirstIterator();
-			}
-		};
+		return () -> AbstractTree.this.dataDepthFirstIterator();
 	}
 
 	@Override
 	@Pure
 	public final Iterable<D> toDataDepthFirstIterable(final DepthFirstNodeOrder nodeOrder) {
-		return new Iterable<D>() {
-			@Override
-			public Iterator<D> iterator() {
-				return AbstractTree.this.dataDepthFirstIterator(nodeOrder);
-			}
-		};
+		return () -> AbstractTree.this.dataDepthFirstIterator(nodeOrder);
 	}
 
 	@Override
 	@Pure
 	public final Iterable<D> toDataDepthFirstIterable(final int infixPosition) {
-		return new Iterable<D>() {
-			@Override
-			public Iterator<D> iterator() {
-				return AbstractTree.this.dataDepthFirstIterator(infixPosition);
-			}
-		};
+		return () -> AbstractTree.this.dataDepthFirstIterator(infixPosition);
 	}
 
 	@Pure
 	@Override
 	public final Iterable<D> toDataBroadFirstIterable() {
-		return new Iterable<D>() {
-			@Override
-			public Iterator<D> iterator() {
-				return AbstractTree.this.dataBroadFirstIterator();
-			}
-		};
+		return () -> AbstractTree.this.dataBroadFirstIterator();
 	}
-
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1604 - “Anonymous inner classes containing only one method should become lambdas”. 
This PR will reduce 40  min of TD.
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1604
 Please let me know if you have any questions.
Fevzi Ozgul