### PR TITLE
Fixing squid: S1854 Dead stores shold be removed fix 2

### DIFF
--- a/core/math/src/main/java/org/arakhne/afc/math/matrix/Matrix3d.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/matrix/Matrix3d.java
@@ -2697,10 +2697,6 @@ public class Matrix3d implements Serializable, Cloneable {
 
             single_values[1] = ha;
             single_values[0] = fa;
-            clt = 1.;
-            crt = 1.;
-            slt = 0.;
-            srt = 0.;
         } else {
             boolean gasmal = true;
 


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1854 - “ Dead stores should be removed ”. 
This PR will remove 60 min of TD.
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1854
 Please let me know if you have any questions.
Fevzi Ozgul