### PR TITLE
Fixing squid: S00117 Local variable and method parameter names should comply with a naming convention part 1

### DIFF
--- a/advanced/attributes/src/main/java/org/arakhne/afc/attrs/collection/AbstractBufferedAttributeProvider.java
+++ b/advanced/attributes/src/main/java/org/arakhne/afc/attrs/collection/AbstractBufferedAttributeProvider.java
@@ -146,12 +146,12 @@ public abstract class AbstractBufferedAttributeProvider extends AbstractAttribut
 
 	@Pure
 	@Override
-	public AttributeValue getAttribute(String name, AttributeValue default_value) {
+	public AttributeValue getAttribute(String name, AttributeValue defaultValue) {
 		AttributeValue value;
 		try {
 			value = new AttributeValueImpl(extractValueFor(name));
 		} catch (AttributeException exception) {
-			value = default_value;
+			value = defaultValue;
 		}
 		return value;
 	}

--- a/advanced/attributes/src/main/java/org/arakhne/afc/attrs/collection/BufferedAttributeCollection.java
+++ b/advanced/attributes/src/main/java/org/arakhne/afc/attrs/collection/BufferedAttributeCollection.java
@@ -199,12 +199,12 @@ public abstract class BufferedAttributeCollection extends AbstractAttributeColle
 
 	@Pure
 	@Override
-	public AttributeValue getAttribute(String name, AttributeValue default_value) {
+	public AttributeValue getAttribute(String name, AttributeValue defaultValue) {
 		final AttributeValue value = extractValueForSafe(name);
 		if (value != null) {
 			return new AttributeValueImpl(value);
 		}
-		return default_value;
+		return defaultValue;
 	}
 
 	@Pure

--- a/advanced/attributes/src/main/java/org/arakhne/afc/attrs/collection/HeapAttributeCollection.java
+++ b/advanced/attributes/src/main/java/org/arakhne/afc/attrs/collection/HeapAttributeCollection.java
@@ -224,11 +224,11 @@ public class HeapAttributeCollection extends AbstractAttributeCollection {
 
 	@Pure
 	@Override
-	public AttributeValue getAttribute(String name, AttributeValue default_value) {
+	public AttributeValue getAttribute(String name, AttributeValue defaultValue) {
 		final AttributeValue value = getStoredAttributeValue(name,
-				default_value == null ? null : default_value.getType());
+				defaultValue == null ? null : defaultValue.getType());
 		if (value == null) {
-			return default_value;
+			return defaultValue;
 		}
 		return value;
 	}

--- a/core/inputoutput/src/main/java/org/arakhne/afc/inputoutput/xml/ColorFormatException.java
+++ b/core/inputoutput/src/main/java/org/arakhne/afc/inputoutput/xml/ColorFormatException.java
@@ -34,10 +34,10 @@ public class ColorFormatException extends Exception {
 
 	/** Constructor.
 	 *
-	 * @param invalid_color is the invalid color
+	 * @param invalidColor is the invalid color
 	 */
-	public ColorFormatException(String invalid_color) {
-		super(invalid_color);
+	public ColorFormatException(String invalidColor) {
+		super(invalidColor);
 	}
 
 }

--- a/core/inputoutput/src/main/java/org/arakhne/afc/inputoutput/xml/DateFormatException.java
+++ b/core/inputoutput/src/main/java/org/arakhne/afc/inputoutput/xml/DateFormatException.java
@@ -34,10 +34,10 @@ public class DateFormatException extends Exception {
 
 	/** Constructor.
 	 *
-	 * @param invalid_date is the invalid date
+	 * @param invalidDate is the invalid date
 	 */
-	public DateFormatException(String invalid_date) {
-		super(invalid_date);
+	public DateFormatException(String invalidDate) {
+		super(invalidDate);
 	}
 
 }

--- a/core/inputoutput/src/main/java/org/arakhne/afc/inputoutput/xml/XMLUtil.java
+++ b/core/inputoutput/src/main/java/org/arakhne/afc/inputoutput/xml/XMLUtil.java
@@ -552,14 +552,14 @@ public final class XMLUtil {
 	 * @param <T> is the type of the enumeration.
 	 * @param document is the XML document to explore.
 	 * @param type is the type of the enumeration.
-	 * @param case_sensitive indicates of the {@code path}'s components are case sensitive.
+	 * @param caseSensitive indicates of the {@code path}'s components are case sensitive.
 	 * @param path is the list of and ended by the attribute's name.
 	 * @return the value of the enumeration or <code>null</code> if none.
 	 */
 	@Pure
-	public static <T extends Enum<T>> T getAttributeEnum(Node document, Class<T> type, boolean case_sensitive, String... path) {
+	public static <T extends Enum<T>> T getAttributeEnum(Node document, Class<T> type, boolean caseSensitive, String... path) {
 		assert document != null : AssertMessages.notNullParameter(0);
-		return getAttributeEnumWithDefault(document, type, case_sensitive, null, path);
+		return getAttributeEnumWithDefault(document, type, caseSensitive, null, path);
 	}
 
 	/** Read an enumeration value.
@@ -627,15 +627,15 @@ public final class XMLUtil {
 	 * the attribute.
 	 *
 	 * @param document is the XML document to explore.
-	 * @param case_sensitive indicates of the {@code path}'s components are case sensitive.
+	 * @param caseSensitive indicates of the {@code path}'s components are case sensitive.
 	 * @param path is the list of and ended by the attribute's name.
 	 * @return the float value of the specified attribute or <code>null</code> if
 	 *     it was node found in the document
 	 */
 	@Pure
-	public static float getAttributeFloat(Node document, boolean case_sensitive, String... path) {
+	public static float getAttributeFloat(Node document, boolean caseSensitive, String... path) {
 		assert document != null : AssertMessages.notNullParameter(0);
-		return getAttributeFloatWithDefault(document, case_sensitive, 0f, path);
+		return getAttributeFloatWithDefault(document, caseSensitive, 0f, path);
 	}
 
 	/** Replies the float value that corresponds to the specified attribute's path.
@@ -703,15 +703,15 @@ public final class XMLUtil {
 	 * the attribute.
 	 *
 	 * @param document is the XML document to explore.
-	 * @param case_sensitive indicates of the {@code path}'s components are case sensitive.
+	 * @param caseSensitive indicates of the {@code path}'s components are case sensitive.
 	 * @param path is the list of and ended by the attribute's name.
 	 * @return the integer value of the specified attribute or <code>null</code> if
 	 *     it was node found in the document
 	 */
 	@Pure
-	public static int getAttributeInt(Node document, boolean case_sensitive, String... path) {
+	public static int getAttributeInt(Node document, boolean caseSensitive, String... path) {
 		assert document != null : AssertMessages.notNullParameter(0);
-		return getAttributeIntWithDefault(document, case_sensitive, 0, path);
+		return getAttributeIntWithDefault(document, caseSensitive, 0, path);
 	}
 
 	/** Replies the integer value that corresponds to the specified attribute's path.
@@ -778,15 +778,15 @@ public final class XMLUtil {
 	 * the attribute.
 	 *
 	 * @param document is the XML document to explore.
-	 * @param case_sensitive indicates of the {@code path}'s components are case sensitive.
+	 * @param caseSensitive indicates of the {@code path}'s components are case sensitive.
 	 * @param path is the list of and ended by the attribute's name.
 	 * @return the long value of the specified attribute or <code>null</code> if
 	 *     it was node found in the document
 	 */
 	@Pure
-	public static long getAttributeLong(Node document, boolean case_sensitive, String... path) {
+	public static long getAttributeLong(Node document, boolean caseSensitive, String... path) {
 		assert document != null : AssertMessages.notNullParameter(0);
-		return getAttributeLongWithDefault(document, case_sensitive, 0, path);
+		return getAttributeLongWithDefault(document, caseSensitive, 0, path);
 	}
 
 	/** Replies the long value that corresponds to the specified attribute's path.
@@ -931,15 +931,15 @@ public final class XMLUtil {
 	 * the attribute.
 	 *
 	 * @param document is the XML document to explore.
-	 * @param case_sensitive indicates of the {@code path}'s components are case sensitive.
+	 * @param caseSensitive indicates of the {@code path}'s components are case sensitive.
 	 * @param path is the list of and ended by the attribute's name.
 	 * @return the UUID in the specified attribute or <code>null</code> if
 	 *     it was node found in the document
 	 */
 	@Pure
-	public static UUID getAttributeUUID(Node document, boolean case_sensitive, String... path) {
+	public static UUID getAttributeUUID(Node document, boolean caseSensitive, String... path) {
 		assert document != null : AssertMessages.notNullParameter(0);
-		return getAttributeUUIDWithDefault(document, case_sensitive, null, path);
+		return getAttributeUUIDWithDefault(document, caseSensitive, null, path);
 	}
 
 	/** Replies the UUID that corresponds to the specified attribute's path.
@@ -1262,14 +1262,14 @@ public final class XMLUtil {
 	 * the desired node.
 	 *
 	 * @param document is the XML document to explore.
-	 * @param case_sensitive indicates of the {@code path}'s components are case sensitive.
+	 * @param caseSensitive indicates of the {@code path}'s components are case sensitive.
 	 * @param path is the list of names.
 	 * @return the node or <code>null</code> if it was not found in the document.
 	 */
 	@Pure
-	public static Element getElementFromPath(Node document, boolean case_sensitive, String... path) {
+	public static Element getElementFromPath(Node document, boolean caseSensitive, String... path) {
 		assert document != null : AssertMessages.notNullParameter(0);
-		return getElementFromPath(document, case_sensitive, 0, path);
+		return getElementFromPath(document, caseSensitive, 0, path);
 	}
 
 	/** Replies the node that corresponds to the specified path.

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d3/afp/PathShadow3afp.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d3/afp/PathShadow3afp.java
@@ -294,15 +294,15 @@ public class PathShadow3afp<B extends RectangularPrism3afp<?, ?, ?, ?, ?, B>> {
 	@SuppressWarnings({"checkstyle:parameternumber", "checkstyle:cyclomaticcomplexity",
       "checkstyle:npathcomplexity"})
 	private static void computeCrossings2(
-			double shadow_x0, double shadow_y0, double shadow_z0,
-			double shadow_x1, double shadow_y1, double shadow_z1,
+			double shadowX0, double shadowY0, double shadowZ0,
+			double shadowX1, double shadowY1, double shadowZ1,
 			double sx0, double sy0, double sz0,
 			double sx1, double sy1, double sz1,
 			PathShadowData data) {
-		final double shadowXMin = Math.min(shadow_x0, shadow_x1);
-		final double shadowXMax = Math.max(shadow_x0, shadow_x1);
-		final double shadowYMin = Math.min(shadow_y0, shadow_y1);
-		final double shadowYMax = Math.max(shadow_y0, shadow_y1);
+		final double shadowXMin = Math.min(shadowX0, shadowX1);
+		final double shadowXMax = Math.max(shadowX0, shadowX1);
+		final double shadowYMin = Math.min(shadowY0, shadowY1);
+		final double shadowYMax = Math.max(shadowY0, shadowY1);
 
         if (sy0 <= shadowYMin && sy1 <= shadowYMin) {
             return;
@@ -340,39 +340,39 @@ public class PathShadow3afp<B extends RectangularPrism3afp<?, ?, ?, ?, ?, B>> {
 				}
 			}
 		} else if (Segment3afp.intersectsSegmentSegmentWithoutEnds(
-				shadow_x0, shadow_y0, shadow_z0, shadow_x1, shadow_y1, shadow_z1,
+				shadowX0, shadowY0, shadowZ0, shadowX1, shadowY1, shadowZ1,
 				sx0, sy0, sz0, sx1, sy1, sz1)) {
 			data.setCrossings(MathConstants.SHAPE_INTERSECTS);
 		} else {
 			final int side1;
 			final int side2;
-            final boolean isUp = shadow_y0 <= shadow_y1;
+            final boolean isUp = shadowY0 <= shadowY1;
 			if (isUp) {
 				side1 = Segment3afp.computeSideLinePoint(
-						shadow_x0, shadow_y0, shadow_z0,
-						shadow_x1, shadow_y1, shadow_z1,
+						shadowX0, shadowY0, shadowZ0,
+						shadowX1, shadowY1, shadowZ1,
 						sx0, sy0, sz0, 0.);
 				side2 = Segment3afp.computeSideLinePoint(
-						shadow_x0, shadow_y0, shadow_z0,
-						shadow_x1, shadow_y1, shadow_z1,
+						shadowX0, shadowY0, shadowZ0,
+						shadowX1, shadowY1, shadowZ1,
 						sx1, sy1, sz1, 0.);
 			} else {
 				side1 = Segment3afp.computeSideLinePoint(
-						shadow_x1, shadow_y1, shadow_z1,
-						shadow_x0, shadow_y0, shadow_z0,
+						shadowX1, shadowY1, shadowZ1,
+						shadowX0, shadowY0, shadowZ0,
 						sx0, sy0, sz0, 0.);
 				side2 = Segment3afp.computeSideLinePoint(
-						shadow_x1, shadow_y1, shadow_z1,
-						shadow_x0, shadow_y0, shadow_z0,
+						shadowX1, shadowY1, shadowZ1,
+						shadowX0, shadowY0, shadowZ0,
 						sx1, sy1, sz1, 0.);
 			}
             if (side1 > 0 || side2 > 0) {
 				computeCrossings3(
-						shadow_x0, shadow_y0,
+						shadowX0, shadowY0,
 						sx0, sy0, sx1, sy1,
 						data, isUp);
 				computeCrossings3(
-						shadow_x1, shadow_y1,
+						shadowX1, shadowY1,
 						sx0, sy0, sx1, sy1,
 						data, !isUp);
 			}


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S00117 - “ Local variable and method parameter names should comply with a naming convention”. 
This PR will remove 40 min of TD.
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S00117
 Please let me know if you have any questions.
Fevzi Ozgul