### PR TITLE
Fixing squid: S00117 Local variable and method parameter names should comply with a naming convention fix 2

### DIFF
--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d3/ai/PathShadow3ai.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d3/ai/PathShadow3ai.java
@@ -276,19 +276,19 @@ public class PathShadow3ai<B extends RectangularPrism3ai<?, ?, ?, ?, ?, B>> {
 
 	@SuppressWarnings({"checkstyle:parameternumber", "checkstyle:npathcomplexity", "checkstyle:cyclomaticcomplexity"})
 	private static void computeCrossings2(
-			int shadow_x0, int shadow_y0, int shadow_z0,
-			int shadow_x1, int shadow_y1, int shadow_z1,
+			int shadowX0, int shadowY0, int shadowZ0,
+			int shadowX1, int shadowY1, int shadowZ1,
 			int sx0, int sy0, int sz0,
 			int sx1, int sy1, int sz1,
 			PathShadowData data) {
-		final int shadowXmin = Math.min(shadow_x0, shadow_x1);
-		final int shadowXmax = Math.max(shadow_x0, shadow_x1);
-		final int shadowYmin = Math.min(shadow_y0, shadow_y1);
-		final int shadowYmax = Math.max(shadow_y0, shadow_y1);
+		final int shadowXmin = Math.min(shadowX0, shadowX1);
+		final int shadowXmax = Math.max(shadowX0, shadowX1);
+		final int shadowYmin = Math.min(shadowY0, shadowY1);
+		final int shadowYmax = Math.max(shadowY0, shadowY1);
 		//TODO final int shadowZmin = Math.min(shadow_z0, shadow_z1);
 		//TODO final int shadowZmax = Math.max(shadow_z0, shadow_z1);
 
-		data.updateShadowLimits(shadow_x0, shadow_y0, shadow_z0, shadow_x1, shadow_y1, shadow_z1);
+		data.updateShadowLimits(shadowX0, shadowY0, shadowZ0, shadowX1, shadowY1, shadowZ1);
 
         if (sy0 < shadowYmin && sy1 < shadowYmin) {
             return;
@@ -328,39 +328,39 @@ public class PathShadow3ai<B extends RectangularPrism3ai<?, ?, ?, ?, ?, B>> {
 				}
 			}
 		} else if (Segment3ai.intersectsSegmentSegment(
-				shadow_x0, shadow_y0, shadow_z0, shadow_x1, shadow_y1, shadow_z1,
+				shadowX0, shadowY0, shadowZ0, shadowX1, shadowY1, shadowZ1,
 				sx0, sy0, sz0, sx1, sy1, sz1)) {
 			data.setCrossings(MathConstants.SHAPE_INTERSECTS);
 		} else {
 			final int side1;
 			final int side2;
-            final boolean isUp = shadow_y0 <= shadow_y1;
+            final boolean isUp = shadowY0 <= shadowY1;
 			if (isUp) {
 				side1 = Segment3ai.computeSideLinePoint(
-						shadow_x0, shadow_y0, shadow_z0,
-						shadow_x1, shadow_y1, shadow_z1,
+						shadowX0, shadowY0, shadowZ0,
+						shadowX1, shadowY1, shadowZ1,
 						sx0, sy0, sz0);
 				side2 = Segment3ai.computeSideLinePoint(
-						shadow_x0, shadow_y0, shadow_z0,
-						shadow_x1, shadow_y1, shadow_z1,
+						shadowX0, shadowY0, shadowZ0,
+						shadowX1, shadowY1, shadowZ1,
 						sx1, sy1, sz1);
 			} else {
 				side1 = Segment3ai.computeSideLinePoint(
-						shadow_x1, shadow_y1, shadow_z1,
-						shadow_x0, shadow_y0, shadow_z0,
+						shadowX1, shadowY1, shadowZ1,
+						shadowX0, shadowY0, shadowZ0,
 						sx0, sy0, sz0);
 				side2 = Segment3ai.computeSideLinePoint(
-						shadow_x1, shadow_y1, shadow_z1,
-						shadow_x0, shadow_y0, shadow_z0,
+						shadowX1, shadowY1, shadowZ1,
+						shadowX0, shadowY0, shadowZ0,
 						sx1, sy1, sz1);
 			}
             if (side1 > 0 || side2 > 0) {
 				computeCrossings3(
-						shadow_x0, shadow_y0, shadow_z0,
+						shadowX0, shadowY0, shadowZ0,
 						sx0, sy0, sz0, sx1, sy1, sz1,
 						data, isUp);
 				computeCrossings3(
-						shadow_x1, shadow_y1, shadow_z1,
+						shadowX1, shadowY1, shadowZ1,
 						sx0, sy0, sz0, sx1, sy1, sz1,
 						data, !isUp);
 			}
@@ -448,25 +448,25 @@ public class PathShadow3ai<B extends RectangularPrism3ai<?, ?, ?, ?, ?, B>> {
 			}
 		}
 
-		public void updateShadowLimits(int shadow_x0, int shadow_y0, int shadow_z0, int shadow_x1, int shadow_y1, int shadow_z1) {
+		public void updateShadowLimits(int shadowX0, int shadowY0, int shadowZ0, int shadowX1, int shadowY1, int shadowZ1) {
 			final int xl;
 			final int yl;
 			final int xh;
 			final int yh;
-            if (shadow_y0 < shadow_y1) {
-				xl = shadow_x0;
-				yl = shadow_y0;
-				xh = shadow_x1;
-				yh = shadow_y1;
-            } else if (shadow_y1 < shadow_y0) {
-				xl = shadow_x1;
-				yl = shadow_y1;
-				xh = shadow_x0;
-				yh = shadow_y0;
+            if (shadowY0 < shadowY1) {
+				xl = shadowX0;
+				yl = shadowY0;
+				xh = shadowX1;
+				yh = shadowY1;
+            } else if (shadowY1 < shadowY0) {
+				xl = shadowX1;
+				yl = shadowY1;
+				xh = shadowX0;
+				yh = shadowY0;
 			} else {
-				xl = Math.min(shadow_x0, shadow_x1);
+				xl = Math.min(shadowX0, shadowX1);
 				xh = xl;
-				yl = shadow_y0;
+				yl = shadowY0;
 				yh = yl;
 			}
 

--- a/core/math/src/main/java/org/arakhne/afc/math/graph/DepthGraphIterator.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/graph/DepthGraphIterator.java
@@ -48,10 +48,10 @@ public class DepthGraphIterator<ST extends GraphSegment<ST, PT>, PT extends Grap
 	/**
 	 * @param graph is the graph associated to this iterator.
 	 * @param depth is the maximal depth to reach (in the metric coordiante system).
-	 * @param position_from_starting_point is the starting position from
+	 * @param positionFromStartingPoint is the starting position from
 	 *     the {@code starting_point} (in meters).
 	 * @param segment is the segment from which to start.
-	 * @param starting_point is the segment's point indicating the direction.
+	 * @param startingPoint is the segment's point indicating the direction.
 	 * @param allowManyReplies may be <code>true</code> to allow to reply many times the same
 	 *     segment, otherwhise <code>false</code>.
 	 * @param assumeOrientedSegments may be <code>true</code> to assume that the same segment has two different
@@ -62,23 +62,23 @@ public class DepthGraphIterator<ST extends GraphSegment<ST, PT>, PT extends Grap
 	public DepthGraphIterator(
 			Graph<ST, PT> graph,
 			double depth,
-			double position_from_starting_point,
+			double positionFromStartingPoint,
 			ST segment,
-			PT starting_point,
+			PT startingPoint,
 			boolean allowManyReplies,
 			boolean assumeOrientedSegments) {
-		this(graph, depth, segment, starting_point, allowManyReplies,
+		this(graph, depth, segment, startingPoint, allowManyReplies,
 				assumeOrientedSegments,
-				-getStartingDistance(position_from_starting_point, segment));
+				-getStartingDistance(positionFromStartingPoint, segment));
 	}
 
 	/**
 	 * @param graph is the graph associated to this iterator.
 	 * @param depth is the maximal depth to reach (in the metric coordiante system).
-	 * @param position_from_starting_point is the starting position from
+	 * @param positionFromStartingPoint is the starting position from
 	 *     the {@code starting_point} (in meters).
 	 * @param segment is the segment from which to start.
-	 * @param starting_point is the segment's point indicating the direction.
+	 * @param startingPoint is the segment's point indicating the direction.
 	 * @param allowManyReplies may be <code>true</code> to allow to reply many times the same
 	 *     segment, otherwhise <code>false</code>.
 	 * @param assumeOrientedSegments may be <code>true</code> to assume that the same segment has two different
@@ -92,13 +92,13 @@ public class DepthGraphIterator<ST extends GraphSegment<ST, PT>, PT extends Grap
 			Graph<ST, PT> graph,
 			double depth,
 			ST segment,
-			PT starting_point,
+			PT startingPoint,
 			boolean allowManyReplies,
 			boolean assumeOrientedSegments,
 			double distanceToReachStartingPoint) {
 		super(graph,
 				new BreadthFirstGraphCourseModel<ST, PT>(),
-				segment, starting_point,
+				segment, startingPoint,
 				allowManyReplies,
 				assumeOrientedSegments,
 				distanceToReachStartingPoint,
@@ -109,7 +109,7 @@ public class DepthGraphIterator<ST extends GraphSegment<ST, PT>, PT extends Grap
 	 * @param graph is the graph associated to this iterator.
 	 * @param depth is the maximal depth to reach (in the metric coordiante system).
 	 * @param segment is the segment from which to start.
-	 * @param starting_point is the segment's point indicating the direction.
+	 * @param startingPoint is the segment's point indicating the direction.
 	 * @param allowManyReplies may be <code>true</code> to allow to reply many times the same
 	 *     segment, otherwhise <code>false</code>.
 	 * @param assumeOrientedSegments may be <code>true</code> to assume that the same segment has two different
@@ -121,11 +121,11 @@ public class DepthGraphIterator<ST extends GraphSegment<ST, PT>, PT extends Grap
 			Graph<ST, PT> graph,
 			double depth,
 			ST segment,
-			PT starting_point,
+			PT startingPoint,
 			boolean allowManyReplies,
 			boolean assumeOrientedSegments) {
 		this(graph, depth, 0.f, segment,
-				starting_point, allowManyReplies,
+				startingPoint, allowManyReplies,
 				assumeOrientedSegments);
 	}
 

--- a/core/math/src/main/java/org/arakhne/afc/math/graph/Graph.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/graph/Graph.java
@@ -70,8 +70,8 @@ public interface Graph<ST extends GraphSegment<ST, PT>, PT extends GraphPoint<PT
 	/** Replies an iterator that permits to move along the road segment's graph
 	 * starting from this road segment and from the specified starting point.
 	 *
-	 * @param starting_segment is the first segment to iterate.
-	 * @param starting_point is the starting point of the iterations.
+	 * @param startingSegment is the first segment to iterate.
+	 * @param startingPoint is the starting point of the iterations.
 	 * @param allowManyReplies may be <code>true</code> to allow to reply many times the same
 	 *     segment, otherwhise <code>false</code>.
 	 * @param assumeOrientedSegments may be <code>true</code> to assume that the same segment has two different
@@ -81,7 +81,7 @@ public interface Graph<ST extends GraphSegment<ST, PT>, PT extends GraphPoint<PT
 	 * @return the iterator.
 	 */
 	@Pure
-	GraphIterator<ST, PT> iterator(ST starting_segment, PT starting_point, boolean allowManyReplies,
+	GraphIterator<ST, PT> iterator(ST startingSegment, PT startingPoint, boolean allowManyReplies,
 			boolean assumeOrientedSegments);
 
 	/** Replies an iterator that permits to move along the segment's graph
@@ -94,7 +94,7 @@ public interface Graph<ST extends GraphSegment<ST, PT>, PT extends GraphPoint<PT
 	 *
 	 * @param startingSegment is the first segment to iterate.
 	 * @param depth is the maximal depth to reach.
-	 * @param position_from_starting_point is the starting position from
+	 * @param positionFromStartingPoint is the starting position from
 	 *     the {@code startingPoint}.
 	 * @param startingPoint is the starting point of the iterations.
 	 * @param allowManyReplies may be <code>true</code> to allow to reply many times the same
@@ -106,7 +106,7 @@ public interface Graph<ST extends GraphSegment<ST, PT>, PT extends GraphPoint<PT
 	 * @return the iterator.
 	 */
 	@Pure
-	GraphIterator<ST, PT> depthIterator(ST startingSegment, double depth, double position_from_starting_point,
+	GraphIterator<ST, PT> depthIterator(ST startingSegment, double depth, double positionFromStartingPoint,
 			PT startingPoint, boolean allowManyReplies, boolean assumeOrientedSegments);
 
 }

--- a/core/math/src/main/java/org/arakhne/afc/math/graph/SubGraph.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/graph/SubGraph.java
@@ -272,13 +272,13 @@ public class SubGraph<ST extends GraphSegment<ST, PT>, PT extends GraphPoint<PT,
 	@Override
 	public GraphIterator<ST, PT> depthIterator(
 			ST startingSegment,
-			double depth, double position_from_starting_point,
+			double depth, double positionFromStartingPoint,
 			PT startingPoint, boolean allowManyReplies,
 			boolean assumeOrientedSegments) {
 		return new DepthSubGraphIterator(
 				filterSegment(startingSegment),
 				depth,
-				position_from_starting_point,
+				positionFromStartingPoint,
 				startingPoint,
 				allowManyReplies, assumeOrientedSegments);
 	}
@@ -291,12 +291,12 @@ public class SubGraph<ST extends GraphSegment<ST, PT>, PT extends GraphPoint<PT,
 
 	@Pure
 	@Override
-	public GraphIterator<ST, PT> iterator(ST starting_segment,
-			PT starting_point, boolean allowManyReplies,
+	public GraphIterator<ST, PT> iterator(ST startingSegment,
+			PT startingPoint, boolean allowManyReplies,
 			boolean assumeOrientedSegments) {
 		return new SubGraphIterator(
-				filterSegment(starting_segment),
-				starting_point,
+				filterSegment(startingSegment),
+				startingPoint,
 				allowManyReplies, assumeOrientedSegments);
 	}
 
@@ -314,29 +314,29 @@ public class SubGraph<ST extends GraphSegment<ST, PT>, PT extends GraphPoint<PT,
 		 *
 		 * @param startingSegment the starting segment.
 		 * @param depth the exploration depth.
-		 * @param position_from_starting_point the position from the starting point.
+		 * @param positionFromStartingPoint the position from the starting point.
 		 * @param startingPoint the starting point, attached to the starting segment.
 		 * @param allowManyReplies indicates if a segment could be reply many times.
 		 * @param assumedOrientedSegments indicates if the segments are assumed to be oriented,
 		 *     i.e. that are from their starting point to their ending points.
 		 */
 		DepthSubGraphIterator(ST startingSegment,
-				double depth, double position_from_starting_point, PT startingPoint,
+				double depth, double positionFromStartingPoint, PT startingPoint,
 				boolean allowManyReplies,
 				boolean assumedOrientedSegments) {
-			super(SubGraph.this, depth, position_from_starting_point,
+			super(SubGraph.this, depth, positionFromStartingPoint,
 					startingSegment, startingPoint,
 					allowManyReplies, assumedOrientedSegments);
 		}
 
 		@Override
 		protected GraphIterationElement<ST, PT> newIterationElement(
-				ST previous_segment, ST segment,
+				ST previousSegment, ST segment,
 				PT point,
 				double distanceToReach,
 				double distanceToConsume) {
 			return new SubGraphIterationElement(
-					previous_segment, segment,
+					previousSegment, segment,
 					point,
 					distanceToReach,
 					distanceToConsume);
@@ -393,12 +393,12 @@ public class SubGraph<ST extends GraphSegment<ST, PT>, PT extends GraphPoint<PT,
 
 		@Override
 		protected GraphIterationElement<ST, PT> newIterationElement(
-				ST previous_segment, ST segment,
+				ST previousSegment, ST segment,
 				PT point,
 				double distanceToReach,
 				double distanceToConsume) {
 			return new SubGraphIterationElement(
-					previous_segment, segment,
+					previousSegment, segment,
 					point,
 					distanceToReach,
 					distanceToConsume);
@@ -423,14 +423,14 @@ public class SubGraph<ST extends GraphSegment<ST, PT>, PT extends GraphPoint<PT,
 		private PT wrappedPoint;
 
 		/**
-		 * @param previous_segment is the previous element that permits to reach this object during an iteration
+		 * @param previousSegment is the previous element that permits to reach this object during an iteration
 		 * @param segment is the current segment
 		 * @param point is the point on which the iteration arrived on the current segment.
 		 * @param distanceToReach1 is the distance that is already consumed.
 		 * @param distanceToConsume1 is the distance to consume including the segment.
 		 */
-		SubGraphIterationElement(ST previous_segment, ST segment, PT point, double distanceToReach1, double distanceToConsume1) {
-			super(previous_segment, segment, point, distanceToReach1, distanceToConsume1);
+		SubGraphIterationElement(ST previousSegment, ST segment, PT point, double distanceToReach1, double distanceToConsume1) {
+			super(previousSegment, segment, point, distanceToReach1, distanceToConsume1);
 		}
 
 		@Override

--- a/core/math/src/main/java/org/arakhne/afc/math/graph/simple/SGraph.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/graph/simple/SGraph.java
@@ -61,16 +61,16 @@ public class SGraph implements Graph<SGraphSegment, SGraphPoint> {
 	@Pure
 	@Override
 	public GraphIterator<SGraphSegment, SGraphPoint> iterator(
-			SGraphSegment starting_segment, SGraphPoint starting_point,
+			SGraphSegment startingSegment, SGraphPoint startingPoint,
 			boolean allowManyReplies, boolean assumeOrientedSegments) {
-		if (starting_segment.getGraph() != this
-				|| starting_point.getGraph() != this) {
+		if (startingSegment.getGraph() != this
+				|| startingPoint.getGraph() != this) {
 			throw new IllegalArgumentException();
 		}
 		return new GraphIterator<>(
 				this,
-				starting_segment,
-				starting_point,
+				startingSegment,
+				startingPoint,
 				allowManyReplies,
 				assumeOrientedSegments,
 				0);
@@ -104,7 +104,7 @@ public class SGraph implements Graph<SGraphSegment, SGraphPoint> {
 	@Override
 	public GraphIterator<SGraphSegment, SGraphPoint> depthIterator(
 			SGraphSegment startingSegment, double depth,
-			double position_from_starting_point, SGraphPoint startingPoint,
+			double positionFromStartingPoint, SGraphPoint startingPoint,
 			boolean allowManyReplies, boolean assumeOrientedSegments) {
 		if (startingSegment.getGraph() != this
 				|| startingPoint.getGraph() != this) {

--- a/core/math/src/main/java/org/arakhne/afc/math/matrix/Matrix3d.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/matrix/Matrix3d.java
@@ -1011,7 +1011,7 @@ public class Matrix3d implements Serializable, Cloneable {
      * @return true if the matrix is nonsingular, or false otherwise.
      */
     @SuppressWarnings({"checkstyle:cyclomaticcomplexity", "checkstyle:npathcomplexity"})
-    private static boolean luDecomposition(double[] matrix0, int[] row_perm) {
+    private static boolean luDecomposition(double[] matrix0, int[] rowPerm) {
         //
         // Reference: Press, Flannery, Teukolsky, Vetterling,
         // _Numerical_Recipes_in_C_, Cambridge University Press,
@@ -1114,7 +1114,7 @@ public class Matrix3d implements Serializable, Cloneable {
             }
 
             // Record row permutation
-            row_perm[j] = imax;
+            rowPerm[j] = imax;
 
             // Is the matrix singular
             if (matrix0[mtx + 3 * j + j] == 0.) {
@@ -1150,7 +1150,7 @@ public class Matrix3d implements Serializable, Cloneable {
      * derived.
      */
     @Pure
-    private static void luBacksubstitution(double[] matrix1, int[] row_perm,
+    private static void luBacksubstitution(double[] matrix1, int[] rowPerm,
             double[] matrix2) {
         //
         // Reference: Press, Flannery, Teukolsky, Vetterling,
@@ -1169,7 +1169,7 @@ public class Matrix3d implements Serializable, Cloneable {
 
             // Forward substitution
             for (int i = 0; i < 3; ++i) {
-                final int ip = row_perm[rp + i];
+                final int ip = rowPerm[rp + i];
                 double sum = matrix2[cv + 3 * ip];
                 matrix2[cv + 3 * ip] = matrix2[cv + 3 * i];
                 if (ii >= 0) {
@@ -2655,14 +2655,14 @@ public class Matrix3d implements Serializable, Cloneable {
         "checkstyle:cyclomaticcomplexity", "checkstyle:npathcomplexity",
         "checkstyle:nestedifdepth", "checkstyle:localvariablename"})
     private static int compute2X2(double f, double g, double h,
-            double[] single_values, double[] snl, double[] csl, double[] snr,
+            double[] singleValues, double[] snl, double[] csl, double[] snr,
             double[] csr, int index) {
 
         final double cb3 = 2.;
         final double cb4 = 1.;
 
-        double ssmax = single_values[0];
-        double ssmin = single_values[1];
+        double ssmax = singleValues[0];
+        double ssmin = singleValues[1];
         double clt = 0.;
         double crt = 0.;
         double slt = 0.;
@@ -2696,8 +2696,8 @@ public class Matrix3d implements Serializable, Cloneable {
         final double ga = Math.abs(gt);
         if (ga == 0.) {
 
-            single_values[1] = ha;
-            single_values[0] = fa;
+            singleValues[1] = ha;
+            singleValues[0] = fa;
         } else {
             boolean gasmal = true;
 
@@ -2832,9 +2832,9 @@ public class Matrix3d implements Serializable, Cloneable {
                 tsign = dSign(cb4, snr[0]) * dSign(cb4, snl[0])
                         * dSign(cb4, h);
             }
-            single_values[index] = dSign(ssmax, tsign);
+            singleValues[index] = dSign(ssmax, tsign);
             final double d1 = tsign * dSign(cb4, f) * dSign(cb4, h);
-            single_values[index + 1] = dSign(ssmin, d1);
+            singleValues[index + 1] = dSign(ssmin, d1);
 
         }
         return 0;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S00117 - “ Local variable and method parameter names should comply with a naming convention”.
This PR will remove 62 min of TD.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S00117
Please let me know if you have any questions.
Fevzi Ozgul