### PR TITLE
Fixing squid: S1854 Dead stores should be removed fix 4

### DIFF
--- a/core/math/src/main/java/org/arakhne/afc/math/matrix/Matrix3d.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/matrix/Matrix3d.java
@@ -2735,14 +2735,9 @@ public class Matrix3d implements Serializable, Cloneable {
 
                 double mm = m * m;
                 double tt = t * t;
-                double s = Math.sqrt(tt + mm);
+                final double s;
 
-                double r;
-                if (l == 0.) {
-                    r = Math.abs(m);
-                } else {
-                    r = Math.sqrt(l * l + mm);
-                }
+                final double r;
 
                 final double a;
 

--- a/maven/maventools/src/main/java/org/arakhne/maven/AbstractArakhneMojo.java
+++ b/maven/maventools/src/main/java/org/arakhne/maven/AbstractArakhneMojo.java
@@ -798,7 +798,7 @@ public abstract class AbstractArakhneMojo extends AbstractMojo {
 		final String name;
 		String version;
 		final String url;
-		Organization organization = null;
+		final Organization organization;
 		final Scm scm;
 		List<Developer> developers;
 		List<Contributor> contributors;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1854 - “ Dead stores should be removed ”. 
This PR will remove 60min of TD.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1854
Please let me know if you have any questions.
Fevzi Ozgul