### PR TITLE
Fixing squid: S1151 Switch case clauses should not have too many lines fix new 2

### DIFF
--- a/advanced/attributes/src/main/java/org/arakhne/afc/attrs/collection/MultiAttributeCollection.java
+++ b/advanced/attributes/src/main/java/org/arakhne/afc/attrs/collection/MultiAttributeCollection.java
@@ -603,12 +603,7 @@ public class MultiAttributeCollection extends MultiAttributeProvider implements 
 					freeMemory();
 					break;
 				case RENAME:
-					MultiAttributeCollection.this.cache.remove(event.getOldName());
-					MultiAttributeCollection.this.cache.remove(event.getName());
-					if (MultiAttributeCollection.this.names != null) {
-						MultiAttributeCollection.this.names.remove(event.getOldName());
-						MultiAttributeCollection.this.names.remove(event.getName());
-					}
+					caseRenameAttributeChange(event);
 					break;
 				case VALUE_UPDATE:
 					MultiAttributeCollection.this.cache.remove(event.getName());
@@ -620,5 +615,13 @@ public class MultiAttributeCollection extends MultiAttributeProvider implements 
 
 	}
 
+	private void caseRenameAttributeChange(AttributeChangeEvent event) {
+		MultiAttributeCollection.this.cache.remove(event.getOldName());
+		MultiAttributeCollection.this.cache.remove(event.getName());
+		if (MultiAttributeCollection.this.names != null) {
+			MultiAttributeCollection.this.names.remove(event.getOldName());
+			MultiAttributeCollection.this.names.remove(event.getName());
+		}
+	}
 }
 

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/afp/BasicPathShadow2afp.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/afp/BasicPathShadow2afp.java
@@ -40,6 +40,8 @@ class BasicPathShadow2afp {
 
     private final PathIterator2afp<?> pathIterator;
 
+    private CoordinatesParam coordinateParam;
+
     private final double boundingMinX;
 
     private final double boundingMinY;
@@ -59,6 +61,8 @@ class BasicPathShadow2afp {
     private double x4ymin;
 
     private double x4ymax;
+
+
 
     /** Construct new path shadow.
      * @param path the path that is constituting the shadow.
@@ -192,7 +196,7 @@ class BasicPathShadow2afp {
         double movy = element.getToY();
         double curx = movx;
         double cury = movy;
-        final CoordinatesParam coordinateParam = new CoordinatesParam(x1, y1, x2, y2, curx, cury);
+        coordinateParam = new CoordinatesParam(x1, y1, x2, y2, curx, cury);
         while (pi.hasNext()) {
             element = pi.next();
             switch (element.getType()) {
@@ -503,22 +507,28 @@ class BasicPathShadow2afp {
      * @mavengroupid $GroupId$
      * @mavenartifactid $ArtifactId$
      */
-    public  final  class CoordinatesParam {
-        private double x1;
+    private    final  class CoordinatesParam {
+        private  double x1;
 
         private double y1;
 
-        private double x2;
+        private  double x2;
 
-        private double y2;
+        private  double y2;
 
-        private double curx;
+        private  double curx;
 
-        private double cury;
+        private  double cury;
 
-        /*Constructor.
-        *Constructor.
-        */
+        /** Determine where the segment is crossing the shadow line.
+         *
+         * @param x1 x   coordinate.
+         * @param y1 y coordinate .
+         * @param x2 x coordinate of the end  point .
+         * @param y2 y coordinate of the end point .
+         * @param curx  current xcoordinate .
+         * @param cury current y coordinate .
+         */
         CoordinatesParam(double x1, double y1, double x2, double y2, double curx, double cury) {
             this.x1 = x1;
             this.y1 = y1;
@@ -529,7 +539,7 @@ class BasicPathShadow2afp {
         }
 
         public double getX1() {
-            return x1;
+            return this.x1;
         }
 
         public void setX1(double x1) {
@@ -537,7 +547,7 @@ class BasicPathShadow2afp {
         }
 
         public double getY1() {
-            return y1;
+            return this.y1;
         }
 
         public void setY1(double y1) {
@@ -545,7 +555,7 @@ class BasicPathShadow2afp {
         }
 
         public double getX2() {
-            return x2;
+            return this.x2;
         }
 
         public void setX2(double x2) {
@@ -553,7 +563,7 @@ class BasicPathShadow2afp {
         }
 
         public double getY2() {
-            return y2;
+            return this.y2;
         }
 
         public void setY2(double y2) {
@@ -561,7 +571,7 @@ class BasicPathShadow2afp {
         }
 
         public double getCurx() {
-            return curx;
+            return this.curx;
         }
 
         public void setCurx(double curx) {
@@ -569,7 +579,7 @@ class BasicPathShadow2afp {
         }
 
         public double getCury() {
-            return cury;
+            return this.cury;
         }
 
         public void setCury(double cury) {

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/afp/BasicPathShadow2afp.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/afp/BasicPathShadow2afp.java
@@ -576,3 +576,4 @@ class BasicPathShadow2afp {
         }
     }
 }
+

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/afp/BasicPathShadow2afp.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/afp/BasicPathShadow2afp.java
@@ -184,7 +184,6 @@ class BasicPathShadow2afp {
             return;
         }
         PathElement2afp element;
-
         element = pi.next();
         if (element.getType() != PathElementType.MOVE_TO) {
             throw new IllegalArgumentException(Locale.getString(Path2afp.class, "E1")); //$NON-NLS-1$
@@ -194,7 +193,6 @@ class BasicPathShadow2afp {
         double curx = movx;
         double cury = movy;
         final CoordinatesParam coordinateParam = new CoordinatesParam(x1, y1, x2, y2, curx, cury);
-        final double[] endxy = new double[2];
         while (pi.hasNext()) {
             element = pi.next();
             switch (element.getType()) {
@@ -205,39 +203,39 @@ class BasicPathShadow2afp {
                 cury = movy;
                 break;
             case LINE_TO:
-                setLineToFromDPathIter(element, coordinateParam, endxy);
+                setLineToFromDiscretizePathIterator(element, coordinateParam);
                 if (this.crossings == MathConstants.SHAPE_INTERSECTS) {
                     return;
                 }
-                curx = endxy[0];
-                cury = endxy[1];
+                curx = element.getToX();
+                cury = element.getToY();
                 break;
             case QUAD_TO:
                 // only for local use.
-                setQuadToFromDPathIter(element, pi, coordinateParam, endxy);
+                setQuadToFromDiscretizePathIterator(element, pi, coordinateParam);
                 if (this.crossings == MathConstants.SHAPE_INTERSECTS) {
                     return;
                 }
-                curx = endxy[0];
-                cury = endxy[1];
+                curx = element.getToX();
+                cury = element.getToY();
                 break;
             case CURVE_TO:
                 // only for local use.
-                setCurveToFromDPathIter(element, pi, coordinateParam, endxy);
+                setCurveToFromDiscretizePathIterator(element, pi, coordinateParam);
                 if (this.crossings == MathConstants.SHAPE_INTERSECTS) {
                     return;
                 }
-                curx = endxy[0];
-                cury = endxy[1];
+                curx = element.getToX();
+                cury = element.getToY();
                 break;
             case ARC_TO:
                 // only for local use.
-                setArcToFromDPathIter(element, pi, coordinateParam, endxy);
+                setArcToFromDiscretizePathIterator(element, pi, coordinateParam);
                 if (this.crossings == MathConstants.SHAPE_INTERSECTS) {
                     return;
                 }
-                curx = endxy[0];
-                cury = endxy[1];
+                curx = element.getToX();
+                cury = element.getToY();
                 break;
             case CLOSE:
                 setCloseFromDiscretizePathIterator(coordinateParam, movx, movy);
@@ -262,51 +260,51 @@ class BasicPathShadow2afp {
         }
     }
 
-    private void setLineToFromDPathIter(PathElement2afp elm, CoordinatesParam param, double[] endxy) {
-        endxy[0] = elm.getToX();
-        endxy[1] = elm.getToY();
+    private void setLineToFromDiscretizePathIterator(PathElement2afp elm, CoordinatesParam param) {
+        final double endx = elm.getToX();
+        final double endy = elm.getToY();
         crossSegmentTwoShadowLines(
                 param.getCurx(), param.getCury(),
-                endxy[0], endxy[1],
+                endx, endy,
                 param.getX1(), param.getY1(), param.getX2(), param.getY2());
     }
 
-    private void setQuadToFromDPathIter(PathElement2afp elm, PathIterator2afp<?> pi, CoordinatesParam param, double[] endxy) {
+    private void setQuadToFromDiscretizePathIterator(PathElement2afp elm, PathIterator2afp<?> pi, CoordinatesParam param) {
         final Path2afp<?, ?, ?, ?, ?, ?> localPath;
-        endxy[0] = elm.getToX();
-        endxy[1] = elm.getToY();
+        final double endx = elm.getToX();
+        final double endy = elm.getToY();
         localPath = pi.getGeomFactory().newPath(pi.getWindingRule());
         localPath.moveTo(param.getCurx(), param.getCury());
         localPath.quadTo(
                 elm.getCtrlX1(), elm.getCtrlY1(),
-                endxy[0], endxy[1]);
+                endx, endy);
         discretizePathIterator(
                 localPath.getPathIterator(MathConstants.SPLINE_APPROXIMATION_RATIO),
                 param.getX1(), param.getY1(), param.getX2(), param.getY2());
     }
 
-    private void setCurveToFromDPathIter(PathElement2afp elm, PathIterator2afp<?> pi, CoordinatesParam prm, double[] endxy) {
+    private void setCurveToFromDiscretizePathIterator(PathElement2afp elm, PathIterator2afp<?> pi, CoordinatesParam prm) {
         final Path2afp<?, ?, ?, ?, ?, ?> localPath;
-        endxy[0] = elm.getToX();
-        endxy[1] = elm.getToY();
+        final double endx = elm.getToX();
+        final double endy = elm.getToY();
         localPath = pi.getGeomFactory().newPath(pi.getWindingRule());
         localPath.moveTo(prm.getCurx(), prm.getCury());
         localPath.curveTo(
                 elm.getCtrlX1(), elm.getCtrlY1(),  elm.getCtrlX2(), elm.getCtrlY2(),
-                endxy[0], endxy[1]);
+                endx, endy);
         discretizePathIterator(
                 localPath.getPathIterator(MathConstants.SPLINE_APPROXIMATION_RATIO),
                 prm.getX1(), prm.getY1(), prm.getX2(), prm.getY2());
     }
 
-    private void setArcToFromDPathIter(PathElement2afp elm, PathIterator2afp<?> pi, CoordinatesParam param, double[] endxy) {
+    private void setArcToFromDiscretizePathIterator(PathElement2afp elm, PathIterator2afp<?> pi, CoordinatesParam param) {
         final Path2afp<?, ?, ?, ?, ?, ?> localPath;
-        endxy[0] = elm.getToX();
-        endxy[1] = elm.getToY();
+        final double endx = elm.getToX();
+        final double endy = elm.getToY();
         localPath = pi.getGeomFactory().newPath(pi.getWindingRule());
         localPath.moveTo(param.getCurx(), param.getCury());
         localPath.arcTo(
-                endxy[0], endxy[1],
+                endx, endy,
                 elm.getRadiusX(), elm.getRadiusY(),
                 elm.getRotationX(), elm.getLargeArcFlag(),
                 elm.getSweepFlag());

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/afp/BasicPathShadow2afp.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/afp/BasicPathShadow2afp.java
@@ -207,7 +207,7 @@ class BasicPathShadow2afp {
                 cury = movy;
                 break;
             case LINE_TO:
-                setLineToFromDiscretizePathIterator(element, coordinateParam);
+                setLineToFromDiscretizePathIterator(element, this.coordinateParam);
                 if (this.crossings == MathConstants.SHAPE_INTERSECTS) {
                     return;
                 }
@@ -216,7 +216,7 @@ class BasicPathShadow2afp {
                 break;
             case QUAD_TO:
                 // only for local use.
-                setQuadToFromDiscretizePathIterator(element, pi, coordinateParam);
+                setQuadToFromDiscretizePathIterator(element, pi, this.coordinateParam);
                 if (this.crossings == MathConstants.SHAPE_INTERSECTS) {
                     return;
                 }
@@ -225,7 +225,7 @@ class BasicPathShadow2afp {
                 break;
             case CURVE_TO:
                 // only for local use.
-                setCurveToFromDiscretizePathIterator(element, pi, coordinateParam);
+                setCurveToFromDiscretizePathIterator(element, pi, this.coordinateParam);
                 if (this.crossings == MathConstants.SHAPE_INTERSECTS) {
                     return;
                 }
@@ -234,7 +234,7 @@ class BasicPathShadow2afp {
                 break;
             case ARC_TO:
                 // only for local use.
-                setArcToFromDiscretizePathIterator(element, pi, coordinateParam);
+                setArcToFromDiscretizePathIterator(element, pi, this.coordinateParam);
                 if (this.crossings == MathConstants.SHAPE_INTERSECTS) {
                     return;
                 }
@@ -242,7 +242,7 @@ class BasicPathShadow2afp {
                 cury = element.getToY();
                 break;
             case CLOSE:
-                setCloseFromDiscretizePathIterator(coordinateParam, movx, movy);
+                setCloseFromDiscretizePathIterator(this.coordinateParam, movx, movy);
                 if (this.crossings != 0) {
                     return;
                 }
@@ -550,40 +550,21 @@ class BasicPathShadow2afp {
             return this.y1;
         }
 
-        public void setY1(double y1) {
-            this.y1 = y1;
-        }
 
         public double getX2() {
             return this.x2;
-        }
-
-        public void setX2(double x2) {
-            this.x2 = x2;
         }
 
         public double getY2() {
             return this.y2;
         }
 
-        public void setY2(double y2) {
-            this.y2 = y2;
-        }
-
         public double getCurx() {
             return this.curx;
         }
 
-        public void setCurx(double curx) {
-            this.curx = curx;
-        }
-
         public double getCury() {
             return this.cury;
-        }
-
-        public void setCury(double cury) {
-            this.cury = cury;
         }
     }
 }

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/afp/BasicPathShadow2afp.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/afp/BasicPathShadow2afp.java
@@ -196,8 +196,8 @@ class BasicPathShadow2afp {
         double movy = element.getToY();
         double curx = movx;
         double cury = movy;
-        this.coordinateParam = new BasicPathShadow2afp.CoordinatesParam(x1, y1, x2, y2, curx, cury);
         while (pi.hasNext()) {
+            this.coordinateParam = new BasicPathShadow2afp.CoordinatesParam(x1, y1, x2, y2, curx, cury);
             element = pi.next();
             switch (element.getType()) {
             case MOVE_TO:

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/afp/BasicPathShadow2afp.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/afp/BasicPathShadow2afp.java
@@ -207,7 +207,7 @@ class BasicPathShadow2afp {
                 cury = movy;
                 break;
             case LINE_TO:
-                setLineToFromDiscretizePathIterator(element, coordinateParam);
+                setLineToFromDiscretizePathIterator(element, this.coordinateParam);
                 if (this.crossings == MathConstants.SHAPE_INTERSECTS) {
                     return;
                 }
@@ -216,7 +216,7 @@ class BasicPathShadow2afp {
                 break;
             case QUAD_TO:
                 // only for local use.
-                setQuadToFromDiscretizePathIterator(element, pi, coordinateParam);
+                setQuadToFromDiscretizePathIterator(element, pi, this.coordinateParam);
                 if (this.crossings == MathConstants.SHAPE_INTERSECTS) {
                     return;
                 }
@@ -225,7 +225,7 @@ class BasicPathShadow2afp {
                 break;
             case CURVE_TO:
                 // only for local use.
-                setCurveToFromDiscretizePathIterator(element, pi, coordinateParam);
+                setCurveToFromDiscretizePathIterator(element, pi, this.coordinateParam);
                 if (this.crossings == MathConstants.SHAPE_INTERSECTS) {
                     return;
                 }
@@ -234,7 +234,7 @@ class BasicPathShadow2afp {
                 break;
             case ARC_TO:
                 // only for local use.
-                setArcToFromDiscretizePathIterator(element, pi, coordinateParam);
+                setArcToFromDiscretizePathIterator(element, pi, this.coordinateParam);
                 if (this.crossings == MathConstants.SHAPE_INTERSECTS) {
                     return;
                 }
@@ -242,7 +242,7 @@ class BasicPathShadow2afp {
                 cury = element.getToY();
                 break;
             case CLOSE:
-                setCloseFromDiscretizePathIterator(coordinateParam, movx, movy);
+                setCloseFromDiscretizePathIterator(this.coordinateParam, movx, movy);
                 if (this.crossings != 0) {
                     return;
                 }
@@ -545,7 +545,6 @@ class BasicPathShadow2afp {
         public double getY1() {
             return this.y1;
         }
-
 
         public double getX2() {
             return this.x2;

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/afp/BasicPathShadow2afp.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/afp/BasicPathShadow2afp.java
@@ -207,7 +207,7 @@ class BasicPathShadow2afp {
                 cury = movy;
                 break;
             case LINE_TO:
-                setLineToFromDiscretizePathIterator(element, this.coordinateParam);
+                setLineToFromDiscretizePathIterator(element, coordinateParam);
                 if (this.crossings == MathConstants.SHAPE_INTERSECTS) {
                     return;
                 }
@@ -216,7 +216,7 @@ class BasicPathShadow2afp {
                 break;
             case QUAD_TO:
                 // only for local use.
-                setQuadToFromDiscretizePathIterator(element, pi, this.coordinateParam);
+                setQuadToFromDiscretizePathIterator(element, pi, coordinateParam);
                 if (this.crossings == MathConstants.SHAPE_INTERSECTS) {
                     return;
                 }
@@ -225,7 +225,7 @@ class BasicPathShadow2afp {
                 break;
             case CURVE_TO:
                 // only for local use.
-                setCurveToFromDiscretizePathIterator(element, pi, this.coordinateParam);
+                setCurveToFromDiscretizePathIterator(element, pi, coordinateParam);
                 if (this.crossings == MathConstants.SHAPE_INTERSECTS) {
                     return;
                 }
@@ -234,7 +234,7 @@ class BasicPathShadow2afp {
                 break;
             case ARC_TO:
                 // only for local use.
-                setArcToFromDiscretizePathIterator(element, pi, this.coordinateParam);
+                setArcToFromDiscretizePathIterator(element, pi, coordinateParam);
                 if (this.crossings == MathConstants.SHAPE_INTERSECTS) {
                     return;
                 }
@@ -242,7 +242,7 @@ class BasicPathShadow2afp {
                 cury = element.getToY();
                 break;
             case CLOSE:
-                setCloseFromDiscretizePathIterator(this.coordinateParam, movx, movy);
+                setCloseFromDiscretizePathIterator(coordinateParam, movx, movy);
                 if (this.crossings != 0) {
                     return;
                 }
@@ -318,7 +318,7 @@ class BasicPathShadow2afp {
     }
 
     private void setCloseFromDiscretizePathIterator(CoordinatesParam param, double movx, double movy) {
-        if (param.cury != movy || param.curx != movx) {
+        if (param.getCury() != movy || param.getCurx() != movx) {
             crossSegmentTwoShadowLines(
                     param.getCurx(), param.getCury(),
                     movx, movy,

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/afp/BasicPathShadow2afp.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/afp/BasicPathShadow2afp.java
@@ -507,7 +507,7 @@ class BasicPathShadow2afp {
      * @mavengroupid $GroupId$
      * @mavenartifactid $ArtifactId$
      */
-    private    final  class CoordinatesParam {
+    private  static  final  class CoordinatesParam {
         private  double x1;
 
         private double y1;

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/afp/BasicPathShadow2afp.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/afp/BasicPathShadow2afp.java
@@ -262,13 +262,13 @@ class BasicPathShadow2afp {
         }
     }
 
-    private void setLineToFromDPathIter(PathElement2afp elm, CoordinatesParam param, double[] exy) {
-        exy[0] = elm.getToX();
-        exy[1] = elm.getToY();
+    private void setLineToFromDPathIter(PathElement2afp elm, CoordinatesParam param, double[] endxy) {
+        endxy[0] = elm.getToX();
+        endxy[1] = elm.getToY();
         crossSegmentTwoShadowLines(
-                param.curx, param.cury,
-                exy[0], exy[1],
-                param.x1, param.y1, param.x2, param.y2);
+                param.getCurx(), param.getCury(),
+                endxy[0], endxy[1],
+                param.getX1(), param.getY1(), param.getX2(), param.getY2());
     }
 
     private void setQuadToFromDPathIter(PathElement2afp elm, PathIterator2afp<?> pi, CoordinatesParam param, double[] endxy) {
@@ -276,36 +276,35 @@ class BasicPathShadow2afp {
         endxy[0] = elm.getToX();
         endxy[1] = elm.getToY();
         localPath = pi.getGeomFactory().newPath(pi.getWindingRule());
-        localPath.moveTo(param.curx, param.cury);
+        localPath.moveTo(param.getCurx(), param.getCury());
         localPath.quadTo(
                 elm.getCtrlX1(), elm.getCtrlY1(),
                 endxy[0], endxy[1]);
         discretizePathIterator(
                 localPath.getPathIterator(MathConstants.SPLINE_APPROXIMATION_RATIO),
-                param.x1, param.y1, param.x2, param.y2);
+                param.getX1(), param.getY1(), param.getX2(), param.getY2());
     }
 
-    private double[] setCurveToFromDPathIter(PathElement2afp elm, PathIterator2afp<?> pi, CoordinatesParam prm, double[] endxy) {
+    private void setCurveToFromDPathIter(PathElement2afp elm, PathIterator2afp<?> pi, CoordinatesParam prm, double[] endxy) {
         final Path2afp<?, ?, ?, ?, ?, ?> localPath;
         endxy[0] = elm.getToX();
         endxy[1] = elm.getToY();
         localPath = pi.getGeomFactory().newPath(pi.getWindingRule());
-        localPath.moveTo(prm.curx, prm.cury);
+        localPath.moveTo(prm.getCurx(), prm.getCury());
         localPath.curveTo(
                 elm.getCtrlX1(), elm.getCtrlY1(),  elm.getCtrlX2(), elm.getCtrlY2(),
                 endxy[0], endxy[1]);
         discretizePathIterator(
                 localPath.getPathIterator(MathConstants.SPLINE_APPROXIMATION_RATIO),
-                prm.x1, prm.y1, prm.x2, prm.y2);
-        return endxy;
+                prm.getX1(), prm.getY1(), prm.getX2(), prm.getY2());
     }
 
-    private double[] setArcToFromDPathIter(PathElement2afp elm, PathIterator2afp<?> pi, CoordinatesParam param, double[] endxy) {
+    private void setArcToFromDPathIter(PathElement2afp elm, PathIterator2afp<?> pi, CoordinatesParam param, double[] endxy) {
         final Path2afp<?, ?, ?, ?, ?, ?> localPath;
         endxy[0] = elm.getToX();
         endxy[1] = elm.getToY();
         localPath = pi.getGeomFactory().newPath(pi.getWindingRule());
-        localPath.moveTo(param.curx, param.cury);
+        localPath.moveTo(param.getCurx(), param.getCury());
         localPath.arcTo(
                 endxy[0], endxy[1],
                 elm.getRadiusX(), elm.getRadiusY(),
@@ -313,16 +312,15 @@ class BasicPathShadow2afp {
                 elm.getSweepFlag());
         discretizePathIterator(
                 localPath.getPathIterator(MathConstants.SPLINE_APPROXIMATION_RATIO),
-                param.x1, param.y1, param.x2, param.y2);
-        return endxy;
+                param.getX1(), param.getY1(), param.getX2(), param.getY2());
     }
 
     private void setCloseFromDiscretizePathIterator(CoordinatesParam param, double movx, double movy) {
         if (param.cury != movy || param.curx != movx) {
             crossSegmentTwoShadowLines(
-                    param.curx, param.cury,
+                    param.getCurx(), param.getCury(),
                     movx, movy,
-                    param.x1, param.y1, param.x2, param.y2);
+                    param.getX1(), param.getY1(), param.getX2(), param.getY2());
         }
     }
 
@@ -520,7 +518,7 @@ class BasicPathShadow2afp {
 
         private double cury;
 
-        private CoordinatesParam(double x1, double y1, double x2, double y2, double curx, double cury) {
+        CoordinatesParam(double x1, double y1, double x2, double y2, double curx, double cury) {
             this.x1 = x1;
             this.y1 = y1;
             this.x2 = x2;
@@ -529,5 +527,52 @@ class BasicPathShadow2afp {
             this.cury = cury;
         }
 
+        public double getX1() {
+            return x1;
+        }
+
+        public void setX1(double x1) {
+            this.x1 = x1;
+        }
+
+        public double getY1() {
+            return y1;
+        }
+
+        public void setY1(double y1) {
+            this.y1 = y1;
+        }
+
+        public double getX2() {
+            return x2;
+        }
+
+        public void setX2(double x2) {
+            this.x2 = x2;
+        }
+
+        public double getY2() {
+            return y2;
+        }
+
+        public void setY2(double y2) {
+            this.y2 = y2;
+        }
+
+        public double getCurx() {
+            return curx;
+        }
+
+        public void setCurx(double curx) {
+            this.curx = curx;
+        }
+
+        public double getCury() {
+            return cury;
+        }
+
+        public void setCury(double cury) {
+            this.cury = cury;
+        }
     }
 }

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/afp/BasicPathShadow2afp.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/afp/BasicPathShadow2afp.java
@@ -503,7 +503,7 @@ class BasicPathShadow2afp {
      * @mavengroupid $GroupId$
      * @mavenartifactid $ArtifactId$
      */
-    private final  class CoordinatesParam {
+    public  final  class CoordinatesParam {
         private double x1;
 
         private double y1;
@@ -516,6 +516,9 @@ class BasicPathShadow2afp {
 
         private double cury;
 
+        /*Constructor.
+        *Constructor.
+        */
         CoordinatesParam(double x1, double y1, double x2, double y2, double curx, double cury) {
             this.x1 = x1;
             this.y1 = y1;

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/afp/BasicPathShadow2afp.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/afp/BasicPathShadow2afp.java
@@ -196,7 +196,7 @@ class BasicPathShadow2afp {
         double movy = element.getToY();
         double curx = movx;
         double cury = movy;
-        coordinateParam = new CoordinatesParam(x1, y1, x2, y2, curx, cury);
+        this.coordinateParam = new BasicPathShadow2afp.CoordinatesParam(x1, y1, x2, y2, curx, cury);
         while (pi.hasNext()) {
             element = pi.next();
             switch (element.getType()) {
@@ -540,10 +540,6 @@ class BasicPathShadow2afp {
 
         public double getX1() {
             return this.x1;
-        }
-
-        public void setX1(double x1) {
-            this.x1 = x1;
         }
 
         public double getY1() {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1151 - “""switch case"" clauses should not have too many lines”.
This PR will reduce 40 min of TD. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1151
Please let me know if you have any questions.
Fevzi Ozgul