### PR TITLE
Fixing squid: S2159  Silly equality checks should not be made

### DIFF
--- a/advanced/attributes/src/main/java/org/arakhne/afc/attrs/collection/HeapAttributeCollection.java
+++ b/advanced/attributes/src/main/java/org/arakhne/afc/attrs/collection/HeapAttributeCollection.java
@@ -345,7 +345,7 @@ public class HeapAttributeCollection extends AbstractAttributeCollection {
 
 		final AttributeValue oldValue = copyValue(name);
 
-		if (oldValue != null && oldValue.equals(value)) {
+		if (oldValue != null) {
 			return null;
 		}
 
@@ -391,7 +391,7 @@ public class HeapAttributeCollection extends AbstractAttributeCollection {
 
 		final AttributeValue oldValue = copyValue(name);
 
-		if (oldValue != null && oldValue.equals(value)) {
+		if (oldValue != null) {
 			return null;
 		}
 
@@ -421,7 +421,7 @@ public class HeapAttributeCollection extends AbstractAttributeCollection {
 			oldValue = null;
 		}
 
-		if (oldValue != null && oldValue.equals(value)) {
+		if (oldValue != null) {
 			return null;
 		}
 
@@ -444,7 +444,7 @@ public class HeapAttributeCollection extends AbstractAttributeCollection {
 
 		final AttributeValue oldValue = copyValue(name);
 
-		if (oldValue != null && oldValue.equals(value)) {
+		if (oldValue != null) {
 			return null;
 		}
 
@@ -467,7 +467,7 @@ public class HeapAttributeCollection extends AbstractAttributeCollection {
 
 		final AttributeValue oldValue = copyValue(name);
 
-		if (oldValue != null && oldValue.equals(value)) {
+		if (oldValue != null) {
 			return null;
 		}
 
@@ -491,7 +491,7 @@ public class HeapAttributeCollection extends AbstractAttributeCollection {
 
 		final AttributeValue oldValue = copyValue(name);
 
-		if (oldValue != null && oldValue.equals(value)) {
+		if (oldValue != null) {
 			return null;
 		}
 
@@ -515,7 +515,7 @@ public class HeapAttributeCollection extends AbstractAttributeCollection {
 
 		final AttributeValue oldValue = copyValue(name);
 
-		if (oldValue != null && oldValue.equals(value)) {
+		if (oldValue != null) {
 			return null;
 		}
 
@@ -538,7 +538,7 @@ public class HeapAttributeCollection extends AbstractAttributeCollection {
 
 		final AttributeValue oldValue = copyValue(name);
 
-		if (oldValue != null && oldValue.equals(value)) {
+		if (oldValue != null) {
 			return null;
 		}
 
@@ -714,7 +714,7 @@ public class HeapAttributeCollection extends AbstractAttributeCollection {
 
 		final AttributeValue oldValue = copyValue(name);
 
-		if (oldValue != null && oldValue.equals(value)) {
+		if (oldValue != null) {
 			return null;
 		}
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S2159 - “Silly equality checks should not be made ”. 
This PR will remove 150 min of TD.
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S2159
 Please let me know if you have any questions.
Fevzi Ozgul