### PR TITLE
Fixing squid: S2184 Math operands should be cast before assignment

### DIFF
--- a/core/inputoutput/src/main/java/org/arakhne/afc/inputoutput/endian/EndianNumbers.java
+++ b/core/inputoutput/src/main/java/org/arakhne/afc/inputoutput/endian/EndianNumbers.java
@@ -107,7 +107,7 @@ public final class EndianNumbers {
 	@Pure
 	public static long toLELong(int b1, int b2, int b3, int b4, int b5, int b6, int b7, int b8) {
 	    return ((b8 & 0xFF) << 56) + ((b7 & 0xFF) << 48) + ((b6 & 0xFF) << 40) + ((b5 & 0xFF) << 32)
-                + ((b4 & 0xFF) << 24) + ((b3 & 0xFF) << 16) + ((b2 & 0xFF) << 8) + (b1 & 0xFF);
+                + ((b4 & 0xFF) << 24) + ((b3 & 0xFF) << 16) + ((b2 & 0xFF) << 8) + (long) (b1 & 0xFF);
     }
 
 	/**
@@ -126,7 +126,7 @@ public final class EndianNumbers {
 	@Pure
 	public static long toBELong(int b1, int b2, int b3, int b4, int b5, int b6, int b7, int b8) {
         return ((b1 & 0xFF) << 56) + ((b2 & 0xFF) << 48) + ((b3 & 0xFF) << 40) + ((b4 & 0xFF) << 32)
-                + ((b5 & 0xFF) << 24) + ((b6 & 0xFF) << 16) + ((b7 & 0xFF) << 8) + (b8 & 0xFF);
+                + ((b5 & 0xFF) << 24) + ((b6 & 0xFF) << 16) + ((b7 & 0xFF) << 8) + (long) (b8 & 0xFF);
     }
 
 	/**

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/ai/BasicPathShadow2ai.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/ai/BasicPathShadow2ai.java
@@ -361,7 +361,7 @@ class BasicPathShadow2ai {
         if (sx0 > shadowXmax && sx1 > shadowXmax) {
             // The line is entirely at the right of the shadow
             if (sy1 != sy0) {
-                final double alpha = (sx1 - sx0) / (sy1 - sy0);
+                final double alpha = (double) (sx1 - sx0) / (sy1 - sy0);
                 if (sy0 < sy1) {
                     if (sy0 <= shadowYmin) {
                         final int xintercept = (int) Math.round(sx0 + (shadowYmin - sy0) * alpha);

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/ai/Rectangle2ai.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/ai/Rectangle2ai.java
@@ -742,7 +742,7 @@ public interface Rectangle2ai<
         } else {
             dy = 0;
         }
-        return dx * dx + dy * dy;
+        return (double) dx * dx + dy * dy;
     }
 
     @Pure
@@ -765,7 +765,7 @@ public interface Rectangle2ai<
         } else {
             dy = 0;
         }
-        return dx + dy;
+        return (double) dx + dy;
     }
 
     @Pure

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/i/Vector2i.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/i/Vector2i.java
@@ -130,13 +130,13 @@ public class Vector2i extends Tuple2i<Vector2i> implements Vector2D<Vector2i, Po
 	@Pure
 	@Override
 	public double getLength() {
-		return Math.sqrt(this.x * this.x + this.y * this.y);
+		return Math.sqrt(this.x * this.x + (double) this.y * this.y);
 	}
 
 	@Pure
 	@Override
 	public double getLengthSquared() {
-		return this.x * this.x + this.y * this.y;
+		return this.x * this.x + (double) this.y * this.y;
 	}
 
 	@Override

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d3/ai/PathShadow3ai.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d3/ai/PathShadow3ai.java
@@ -302,7 +302,7 @@ public class PathShadow3ai<B extends RectangularPrism3ai<?, ?, ?, ?, ?, B>> {
         if (sx0 > shadowXmax && sx1 > shadowXmax) {
 			// The line is entirely at the right of the shadow
 			if (sy1 != sy0) {
-                final double alpha = (sx1 - sx0) / (sy1 - sy0);
+                final double alpha = (double) (sx1 - sx0) / (sy1 - sy0);
                 if (sy0 < sy1) {
                     if (sy0 <= shadowYmin) {
 						final int xintercept = (int) Math.round(sx0 + (shadowYmin - sy0) * alpha);

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d3/ai/RectangularPrism3ai.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d3/ai/RectangularPrism3ai.java
@@ -601,7 +601,7 @@ public interface RectangularPrism3ai<
 		} else {
 			dz = 0;
 		}
-        return dx * dx + dy * dy + dz * dz;
+        return (double) dx * dx + dy * dy + dz * dz;
 	}
 
 	@Pure
@@ -632,7 +632,7 @@ public interface RectangularPrism3ai<
 		} else {
 			dz = 0;
 		}
-		return dx + dy + dz;
+		return (double) dx + dy + dz;
 	}
 
 	@Pure

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d3/i/Vector3i.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d3/i/Vector3i.java
@@ -122,13 +122,13 @@ public class Vector3i extends Tuple3i<Vector3i> implements Vector3D<Vector3i, Po
 	@Pure
 	@Override
 	public double getLength() {
-		return Math.sqrt(this.x * this.x + this.y * this.y + this.z * this.z);
+		return Math.sqrt(this.x * this.x + this.y * this.y + (double) this.z * this.z);
 	}
 
 	@Pure
 	@Override
 	public double getLengthSquared() {
-		return this.x * this.x + this.y * this.y + this.z * this.z;
+		return (double) this.x * this.x + this.y * this.y + this.z * this.z;
 	}
 
 	@Override


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S2184 - “Math operands should be cast before assignment”. 
This PR will remove 80min of TD.
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S2184
 Please let me know if you have any questions.
Fevzi Ozgul