### PR TITLE
Fixing squid: S2183 Ints and longs should not be shifted by more than their number of bits-1

### DIFF
--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/Segment2dfx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/Segment2dfx.java
@@ -131,7 +131,7 @@ public class Segment2dfx extends AbstractShape2dfx<Segment2dfx>
 		bits = 31 * bits + Double.doubleToLongBits(getX2());
 		bits = 31 * bits + Double.doubleToLongBits(getY2());
 		final int b = (int) bits;
-		return b ^ (b >> 32);
+		return b;
 	}
 
 	@Pure

--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/Segment2dfx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/Segment2dfx.java
@@ -131,7 +131,7 @@ public class Segment2dfx extends AbstractShape2dfx<Segment2dfx>
 		bits = 31 * bits + Double.doubleToLongBits(getX2());
 		bits = 31 * bits + Double.doubleToLongBits(getY2());
 		final int b = (int) bits;
-		return b;
+		return  b ^ (b >> 31);
 	}
 
 	@Pure

--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/ifx/Segment2ifx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/ifx/Segment2ifx.java
@@ -129,7 +129,7 @@ public class Segment2ifx extends AbstractShape2ifx<Segment2ifx>
 		bits = 31 * bits + Double.doubleToLongBits(getX2());
 		bits = 31 * bits + Double.doubleToLongBits(getY2());
 		final int b = (int) bits;
-		return b;
+		return b ^ (b >> 31);
 	}
 
 	@Pure

--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/ifx/Segment2ifx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/ifx/Segment2ifx.java
@@ -129,7 +129,7 @@ public class Segment2ifx extends AbstractShape2ifx<Segment2ifx>
 		bits = 31 * bits + Double.doubleToLongBits(getX2());
 		bits = 31 * bits + Double.doubleToLongBits(getY2());
 		final int b = (int) bits;
-		return b ^ (b >> 32);
+		return b;
 	}
 
 	@Pure

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d3/ImmutablePoint3D.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d3/ImmutablePoint3D.java
@@ -85,7 +85,7 @@ final class ImmutablePoint3D implements UnmodifiablePoint3D<ImmutablePoint3D, Im
 		bits = 31 * bits + Double.doubleToLongBits(this.y);
 		bits = 31 * bits + Double.doubleToLongBits(this.z);
 		final int b = (int) bits;
-		return b;
+		return b ^ (b >> 31);
 	}
 
 	@Pure

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d3/ImmutablePoint3D.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d3/ImmutablePoint3D.java
@@ -85,7 +85,7 @@ final class ImmutablePoint3D implements UnmodifiablePoint3D<ImmutablePoint3D, Im
 		bits = 31 * bits + Double.doubleToLongBits(this.y);
 		bits = 31 * bits + Double.doubleToLongBits(this.z);
 		final int b = (int) bits;
-		return b ^ (b >> 32);
+		return b;
 	}
 
 	@Pure

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d3/ImmutableVector3D.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d3/ImmutableVector3D.java
@@ -90,7 +90,7 @@ final class ImmutableVector3D implements
 		bits = 31 * bits + Double.doubleToLongBits(this.y);
 		bits = 31 * bits + Double.doubleToLongBits(this.z);
 		final int b = (int) bits;
-		return b;
+		return b ^ (b >> 31);
 	}
 
 	@Pure

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d3/ImmutableVector3D.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d3/ImmutableVector3D.java
@@ -90,7 +90,7 @@ final class ImmutableVector3D implements
 		bits = 31 * bits + Double.doubleToLongBits(this.y);
 		bits = 31 * bits + Double.doubleToLongBits(this.z);
 		final int b = (int) bits;
-		return b ^ (b >> 32);
+		return b;
 	}
 
 	@Pure

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d3/Vector3D.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d3/Vector3D.java
@@ -1198,7 +1198,7 @@ public interface Vector3D<RV extends Vector3D<? super RV, ? super RP>, RP extend
 			bits = 31 * bits + Double.doubleToLongBits(this.scalar);
 			bits = 31 * bits + ((this.vector == null) ? 0 : this.vector.hashCode());
 			final int b = (int) bits;
-			return b;
+			return b ^ (b >> 31);
 		}
 
 		/** Replies the scalar result.

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d3/Vector3D.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d3/Vector3D.java
@@ -1198,7 +1198,7 @@ public interface Vector3D<RV extends Vector3D<? super RV, ? super RP>, RP extend
 			bits = 31 * bits + Double.doubleToLongBits(this.scalar);
 			bits = 31 * bits + ((this.vector == null) ? 0 : this.vector.hashCode());
 			final int b = (int) bits;
-			return b ^ (b >> 32);
+			return b;
 		}
 
 		/** Replies the scalar result.

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d3/d/RectangularPrism3d.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d3/d/RectangularPrism3d.java
@@ -239,7 +239,7 @@ public class RectangularPrism3d extends AbstractShape3d<RectangularPrism3d>
 		bits = 31 * bits + Double.doubleToLongBits(this.maxy);
 		bits = 31 * bits + Double.doubleToLongBits(this.maxz);
 		final int b = (int) bits;
-		return b ^ (b >> 32);
+		return b;
 	}
 
 }

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d3/d/RectangularPrism3d.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d3/d/RectangularPrism3d.java
@@ -239,7 +239,7 @@ public class RectangularPrism3d extends AbstractShape3d<RectangularPrism3d>
 		bits = 31 * bits + Double.doubleToLongBits(this.maxy);
 		bits = 31 * bits + Double.doubleToLongBits(this.maxz);
 		final int b = (int) bits;
-		return b;
+		return b ^ (b >> 31);
 	}
 
 }

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d3/i/AbstractPrism3i.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d3/i/AbstractPrism3i.java
@@ -225,7 +225,7 @@ public abstract class AbstractPrism3i<IT extends AbstractPrism3i<?>>
 		bits = 31 * bits + this.maxx;
 		bits = 31 * bits + this.maxy;
 		bits = 31 * bits + this.maxz;
-		return bits;
+		return bits ^ (bits >> 31);
 	}
 
 }

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d3/i/AbstractPrism3i.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d3/i/AbstractPrism3i.java
@@ -225,7 +225,7 @@ public abstract class AbstractPrism3i<IT extends AbstractPrism3i<?>>
 		bits = 31 * bits + this.maxx;
 		bits = 31 * bits + this.maxy;
 		bits = 31 * bits + this.maxz;
-		return bits ^ (bits >> 32);
+		return bits;
 	}
 
 }


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S2183 - “Ints and longs should not be shifted by more than their number of bits-1”. 
This PR will remove 70min of TD.
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S2183
 Please let me know if you have any questions.
Fevzi Ozgul