### PR TITLE
Fixing squid: S2183  Ints and longs should not be shifted by more than their number of bits-1

### DIFF
--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d3/ifx/PathElement3ifx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d3/ifx/PathElement3ifx.java
@@ -299,7 +299,7 @@ public abstract class PathElement3ifx implements PathElement3ai {
 			bits = 31 * bits + getToX();
 			bits = 31 * bits + getToY();
 			bits = 31 * bits + getToZ();
-			return bits;
+			return bits ^ (bits >> 31);
 		}
 
         @Pure
@@ -536,7 +536,7 @@ public abstract class PathElement3ifx implements PathElement3ai {
 			bits = 31 * bits + getFromX();
 			bits = 31 * bits + getFromY();
 			bits = 31 * bits + getFromZ();
-			return bits;
+			return bits ^ (bits >> 31);
 		}
 
         @Pure
@@ -801,7 +801,7 @@ public abstract class PathElement3ifx implements PathElement3ai {
 			bits = 31 * bits + getFromX();
 			bits = 31 * bits + getFromY();
 			bits = 31 * bits + getFromZ();
-			return bits;
+			return bits ^ (bits >> 31);
 		}
 
         @Pure
@@ -1101,7 +1101,7 @@ public abstract class PathElement3ifx implements PathElement3ai {
 			bits = 31 * bits + getFromX();
 			bits = 31 * bits + getFromY();
 			bits = 31 * bits + getFromZ();
-			return bits;
+			return bits ^ (bits >> 31);
 		}
 
         @Pure
@@ -1371,7 +1371,7 @@ public abstract class PathElement3ifx implements PathElement3ai {
 			bits = 31 * bits + getFromX();
 			bits = 31 * bits + getFromY();
 			bits = 31 * bits + getFromZ();
-			return bits;
+			return bits ^ (bits >> 31);
 		}
 
         @Pure

--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d3/ifx/PathElement3ifx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d3/ifx/PathElement3ifx.java
@@ -299,7 +299,7 @@ public abstract class PathElement3ifx implements PathElement3ai {
 			bits = 31 * bits + getToX();
 			bits = 31 * bits + getToY();
 			bits = 31 * bits + getToZ();
-			return bits ^ bits >> 32;
+			return bits;
 		}
 
         @Pure
@@ -536,7 +536,7 @@ public abstract class PathElement3ifx implements PathElement3ai {
 			bits = 31 * bits + getFromX();
 			bits = 31 * bits + getFromY();
 			bits = 31 * bits + getFromZ();
-			return bits ^ bits >> 32;
+			return bits;
 		}
 
         @Pure
@@ -801,7 +801,7 @@ public abstract class PathElement3ifx implements PathElement3ai {
 			bits = 31 * bits + getFromX();
 			bits = 31 * bits + getFromY();
 			bits = 31 * bits + getFromZ();
-			return bits ^ bits >> 32;
+			return bits;
 		}
 
         @Pure
@@ -1101,7 +1101,7 @@ public abstract class PathElement3ifx implements PathElement3ai {
 			bits = 31 * bits + getFromX();
 			bits = 31 * bits + getFromY();
 			bits = 31 * bits + getFromZ();
-			return bits ^ bits >> 32;
+			return bits;
 		}
 
         @Pure
@@ -1371,7 +1371,7 @@ public abstract class PathElement3ifx implements PathElement3ai {
 			bits = 31 * bits + getFromX();
 			bits = 31 * bits + getFromY();
 			bits = 31 * bits + getFromZ();
-			return bits ^ bits >> 32;
+			return bits;
 		}
 
         @Pure

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d3/i/PathElement3i.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d3/i/PathElement3i.java
@@ -173,7 +173,7 @@ public abstract class PathElement3i implements PathElement3ai {
             bits = 31 * bits + getToX();
             bits = 31 * bits + getToY();
             bits = 31 * bits + getToZ();
-            return bits;
+            return bits ^ (bits >> 31);
         }
 
         @Pure
@@ -481,7 +481,7 @@ public abstract class PathElement3i implements PathElement3ai {
             bits = 31 * bits + getFromX();
             bits = 31 * bits + getFromY();
             bits = 31 * bits + getFromZ();
-            return bits;
+            return bits ^ (bits >> 31);
         }
 
         @Pure
@@ -668,7 +668,7 @@ public abstract class PathElement3i implements PathElement3ai {
             bits = 31 * bits + getFromX();
             bits = 31 * bits + getFromY();
             bits = 31 * bits + getFromZ();
-            return bits ^ bits >> 32;
+            return bits ^ bits >> 31;
         }
 
         @Pure
@@ -831,7 +831,7 @@ public abstract class PathElement3i implements PathElement3ai {
             bits = 31 * bits + getFromX();
             bits = 31 * bits + getFromY();
             bits = 31 * bits + getFromZ();
-            return bits;
+            return bits ^ (bits >> 31);
         }
 
         @Pure

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d3/i/PathElement3i.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d3/i/PathElement3i.java
@@ -319,7 +319,7 @@ public abstract class PathElement3i implements PathElement3ai {
             bits = 31 * bits + getFromX();
             bits = 31 * bits + getFromY();
             bits = 31 * bits + getFromZ();
-            return bits;
+            return bits ^ (bits >> 31);
         }
 
         @Pure

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d3/i/PathElement3i.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d3/i/PathElement3i.java
@@ -173,7 +173,7 @@ public abstract class PathElement3i implements PathElement3ai {
             bits = 31 * bits + getToX();
             bits = 31 * bits + getToY();
             bits = 31 * bits + getToZ();
-            return bits ^ (bits >> 32);
+            return bits;
         }
 
         @Pure
@@ -319,7 +319,7 @@ public abstract class PathElement3i implements PathElement3ai {
             bits = 31 * bits + getFromX();
             bits = 31 * bits + getFromY();
             bits = 31 * bits + getFromZ();
-            return bits ^ bits >> 32;
+            return bits;
         }
 
         @Pure
@@ -481,7 +481,7 @@ public abstract class PathElement3i implements PathElement3ai {
             bits = 31 * bits + getFromX();
             bits = 31 * bits + getFromY();
             bits = 31 * bits + getFromZ();
-            return bits ^ bits >> 32;
+            return bits;
         }
 
         @Pure
@@ -831,7 +831,7 @@ public abstract class PathElement3i implements PathElement3ai {
             bits = 31 * bits + getFromX();
             bits = 31 * bits + getFromY();
             bits = 31 * bits + getFromZ();
-            return bits ^ (bits >> 32);
+            return bits;
         }
 
         @Pure


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2183 - “Ints and longs should not be shifted by more than their number of bits-1”. 
This PR will remove 60min of TD.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2183
Please let me know if you have any questions.
Fevzi Ozgul