### PR TITLE
Fixing squid: S2178 Short-circuit logic should be used in boolean contexts

### DIFF
--- a/advanced/attributes/src/main/java/org/arakhne/afc/attrs/collection/MultiAttributeCollection.java
+++ b/advanced/attributes/src/main/java/org/arakhne/afc/attrs/collection/MultiAttributeCollection.java
@@ -185,7 +185,7 @@ public class MultiAttributeCollection extends MultiAttributeProvider implements 
 			boolean changed = false;
 			for (final AttributeProvider c : containers()) {
 				if (c instanceof AttributeCollection) {
-					changed = ((AttributeCollection) c).removeAllAttributes() | changed;
+					changed = ((AttributeCollection) c).removeAllAttributes() || changed;
 				}
 			}
 			if (changed) {
@@ -208,7 +208,7 @@ public class MultiAttributeCollection extends MultiAttributeProvider implements 
 			for (final AttributeProvider c : containers()) {
 				assign(oldValue, c.getAttribute(name));
 				if (c instanceof AttributeCollection) {
-					changed = ((AttributeCollection) c).removeAttribute(name) | changed;
+					changed = ((AttributeCollection) c).removeAttribute(name) || changed;
 				}
 			}
 			if (changed) {
@@ -237,7 +237,7 @@ public class MultiAttributeCollection extends MultiAttributeProvider implements 
 			for (final AttributeProvider c : containers()) {
 				assign(currentValue, c.getAttribute(oldname));
 				if (c instanceof AttributeCollection) {
-					changed = ((AttributeCollection) c).renameAttribute(oldname, newname) | changed;
+					changed = ((AttributeCollection) c).renameAttribute(oldname, newname) || changed;
 				}
 			}
 			if (changed) {
@@ -265,7 +265,7 @@ public class MultiAttributeCollection extends MultiAttributeProvider implements 
 			for (final AttributeProvider c : containers()) {
 				assign(currentValue, c.getAttribute(oldname));
 				if (c instanceof AttributeCollection) {
-					changed = ((AttributeCollection) c).renameAttribute(oldname, newname, overwrite) | changed;
+					changed = ((AttributeCollection) c).renameAttribute(oldname, newname, overwrite) || changed;
 				}
 			}
 			if (changed) {

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d3/ai/RectangularPrism3ai.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d3/ai/RectangularPrism3ai.java
@@ -497,7 +497,7 @@ public interface RectangularPrism3ai<
 				iterator,
 				getMinX(), getMinY(), getMinZ(), getMaxX(), getMaxY(), getMaxZ(),
 				CrossingComputationType.SIMPLE_INTERSECTION_WHEN_NOT_POLYGON);
-        return crossings == MathConstants.SHAPE_INTERSECTS | (crossings & mask) != 0;
+        return crossings == MathConstants.SHAPE_INTERSECTS || (crossings & mask) != 0;
 
 	}
 

--- a/core/math/src/main/java/org/arakhne/afc/math/tree/iterator/PrefixDepthFirstTreeIterator.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/tree/iterator/PrefixDepthFirstTreeIterator.java
@@ -88,7 +88,7 @@ public class PrefixDepthFirstTreeIterator<N extends TreeNode<?, N>>
 	@Override
 	@Pure
 	protected N toTraversableChild(N parent, N child) {
-		assert child != null & parent != null;
+		assert child != null && parent != null;
 		if (this.selector == null || this.selector.nodeCouldBeTreatedByIterator(child)) {
 			return child;
 		}

--- a/core/math/src/main/java/org/arakhne/afc/math/tree/node/AbstractParentlessTreeNode.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/tree/node/AbstractParentlessTreeNode.java
@@ -746,7 +746,7 @@ public abstract class AbstractParentlessTreeNode<D, N extends AbstractParentless
 		public boolean removeAll(Collection<?> collection) {
 			boolean changed = false;
 			for (final Object o : collection) {
-				changed = remove(o) | changed;
+				changed = remove(o) || changed;
 			}
 			return changed;
 		}

--- a/core/references/src/main/java/org/arakhne/afc/references/AbstractReferencedValueMap.java
+++ b/core/references/src/main/java/org/arakhne/afc/references/AbstractReferencedValueMap.java
@@ -335,7 +335,7 @@ public abstract class AbstractReferencedValueMap<K, V> extends AbstractMap<K, V>
 		public final boolean addAll(Collection<? extends java.util.Map.Entry<K, V>> collection) {
 			boolean changed = true;
 			for (final java.util.Map.Entry<K, V> entry : collection) {
-				changed = add(entry) | changed;
+				changed = add(entry) || changed;
 			}
 			return changed;
 		}


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S2178 - “Short-circuit logic should be used in boolean contexts”. 
TD removal: 50min
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S2178
 Please let me know if you have any questions.
Fevzi Ozgul