### PR TITLE
Fixing squid: S1155 Collection.isEmpty() should be used to test for emptiness

### DIFF
--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/Path2dfx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/dfx/Path2dfx.java
@@ -602,7 +602,7 @@ public class Path2dfx extends AbstractShape2dfx<Path2dfx>
     public void moveTo(double x, double y) {
         if (this.types != null && !this.types.isEmpty()
                 && this.types.get(this.types.size() - 1) == PathElementType.MOVE_TO) {
-            assert this.coords != null && this.coords.size() >= 1;
+            assert this.coords != null && !this.coords.isEmpty();
             final int idx = this.coords.size() - 1;
             this.coords.set(idx, getGeomFactory().newPoint(x, y));
         } else {
@@ -617,7 +617,7 @@ public class Path2dfx extends AbstractShape2dfx<Path2dfx>
         assert position != null : AssertMessages.notNullParameter();
         if (this.types != null && !this.types.isEmpty()
                 && this.types.get(this.types.size() - 1) == PathElementType.MOVE_TO) {
-            assert this.coords != null && this.coords.size() >= 1;
+            assert this.coords != null && !this.coords.isEmpty();
             final int idx = this.coords.size() - 1;
             this.coords.set(idx, getGeomFactory().convertToPoint(position));
         } else {
@@ -736,7 +736,7 @@ public class Path2dfx extends AbstractShape2dfx<Path2dfx>
 
     @Override
     public void setLastPoint(Point2D<?, ?> point) {
-        if (this.coords != null && this.coords.size() >= 1) {
+        if (this.coords != null && !this.coords.isEmpty()) {
             final int idx = this.coords.size() - 1;
             this.coords.get(idx).set(point.getX(), point.getY());
         } else {

--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/ifx/Path2ifx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d2/ifx/Path2ifx.java
@@ -616,7 +616,7 @@ public class Path2ifx extends AbstractShape2ifx<Path2ifx>
 	public void moveTo(int x, int y) {
 	    if (this.types != null && !this.types.isEmpty()
 	            && this.types.get(this.types.size() - 1) == PathElementType.MOVE_TO) {
-	        assert this.coords != null && this.coords.size() >= 1;
+	        assert this.coords != null && !this.coords.isEmpty();
 	        final int idx = this.coords.size() - 1;
 	        this.coords.set(idx, getGeomFactory().newPoint(x, y));
 	    } else {
@@ -631,7 +631,7 @@ public class Path2ifx extends AbstractShape2ifx<Path2ifx>
 	    assert position != null : AssertMessages.notNullParameter();
 		if (this.types != null && !this.types.isEmpty()
 				&& this.types.get(this.types.size() - 1) == PathElementType.MOVE_TO) {
-			assert this.coords != null && this.coords.size() >= 1;
+			assert this.coords != null && !this.coords.isEmpty();
 			final int idx = this.coords.size() - 1;
 			this.coords.set(idx, getGeomFactory().convertToPoint(position));
 		} else {
@@ -738,7 +738,7 @@ public class Path2ifx extends AbstractShape2ifx<Path2ifx>
 
 	@Override
 	public void setLastPoint(int x, int y) {
-	    if (this.coords != null && this.coords.size() >= 1) {
+	    if (this.coords != null && !this.coords.isEmpty()) {
 	        final int idx = this.coords.size() - 1;
 	        final Point2ifx point = this.coords.get(idx);
 	        point.setX(x);
@@ -750,7 +750,7 @@ public class Path2ifx extends AbstractShape2ifx<Path2ifx>
 
 	@Override
 	public void setLastPoint(Point2D<?, ?> point) {
-		if (this.coords != null && this.coords.size() >= 1) {
+		if (this.coords != null && !this.coords.isEmpty()) {
 			final int idx = this.coords.size() - 1;
 			this.coords.get(idx).set(point.ix(), point.iy());
 		} else {

--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d3/dfx/Path3dfx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d3/dfx/Path3dfx.java
@@ -615,7 +615,7 @@ public class Path3dfx
 	public void moveTo(double x, double y, double z) {
 	    if (this.types != null && !this.types.isEmpty()
 	            && this.types.get(this.types.size() - 1) == PathElementType.MOVE_TO) {
-	        assert this.coords != null && this.coords.size() >= 1;
+	        assert this.coords != null && !this.coords.isEmpty();
 	        final int idx = this.coords.size() - 1;
 	        this.coords.set(idx, getGeomFactory().newPoint(x, y, z));
 	    } else {
@@ -630,7 +630,7 @@ public class Path3dfx
 	    assert position != null : AssertMessages.notNullParameter();
 		if (this.types != null && !this.types.isEmpty()
 				&& this.types.get(this.types.size() - 1) == PathElementType.MOVE_TO) {
-			assert this.coords != null && this.coords.size() >= 1;
+			assert this.coords != null && !this.coords.isEmpty();
 			final int idx = this.coords.size() - 1;
 			this.coords.set(idx, getGeomFactory().convertToPoint(position));
 		} else {

--- a/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d3/ifx/Path3ifx.java
+++ b/advanced/mathfx/src/main/java/org/arakhne/afc/math/geometry/d3/ifx/Path3ifx.java
@@ -636,7 +636,7 @@ public class Path3ifx
 	public void moveTo(int x, int y, int z) {
 	    if (this.types != null && !this.types.isEmpty()
 	            && this.types.get(this.types.size() - 1) == PathElementType.MOVE_TO) {
-	        assert this.coords != null && this.coords.size() >= 1;
+	        assert this.coords != null && !this.coords.isEmpty();
 	        final int idx = this.coords.size() - 1;
 	        this.coords.set(idx, getGeomFactory().newPoint(x, y, z));
 	    } else {
@@ -651,7 +651,7 @@ public class Path3ifx
 	    assert position != null : AssertMessages.notNullParameter();
 		if (this.types != null && !this.types.isEmpty()
 				&& this.types.get(this.types.size() - 1) == PathElementType.MOVE_TO) {
-			assert this.coords != null && this.coords.size() >= 1;
+			assert this.coords != null && !this.coords.isEmpty();
 			final int idx = this.coords.size() - 1;
 			this.coords.set(idx, getGeomFactory().convertToPoint(position));
 		} else {
@@ -760,7 +760,7 @@ public class Path3ifx
 
 	@Override
 	public void setLastPoint(int x, int y, int z) {
-		if (this.coords != null && this.coords.size() >= 1) {
+		if (this.coords != null && !this.coords.isEmpty()) {
 			final int idx = this.coords.size() - 1;
 			final Point3ifx point = this.coords.get(idx);
 			point.setX(x);

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/afp/MultiShape2afp.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/afp/MultiShape2afp.java
@@ -563,7 +563,7 @@ public interface MultiShape2afp<
 			this.isPolyline = list.size() == 1
 					&& this.shapeIterator != null
 					&& this.shapeIterator.isPolyline();
-			this.isCurved = list.size() > 0
+			this.isCurved = !list.isEmpty()
 					&& this.shapeIterator != null
 					&& this.shapeIterator.isCurved();
 		}

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/ai/MultiShape2ai.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/ai/MultiShape2ai.java
@@ -408,7 +408,7 @@ public interface MultiShape2ai<
 			this.isPolyline = list.size() == 1
 					&& this.shapeIterator != null
 					&& this.shapeIterator.isPolyline();
-			this.isCurved = list.size() > 0
+			this.isCurved = !list.isEmpty()
 					&& this.shapeIterator != null
 					&& this.shapeIterator.isCurved();
 		}

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d3/afp/MultiShape3afp.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d3/afp/MultiShape3afp.java
@@ -388,7 +388,7 @@ public interface MultiShape3afp<
 			this.isPolyline = list.size() == 1
 					&& this.shapeIterator != null
 					&& this.shapeIterator.isPolyline();
-			this.isCurved = list.size() > 0
+			this.isCurved = !list.isEmpty()
 					&& this.shapeIterator != null
 					&& this.shapeIterator.isCurved();
 		}

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d3/ai/MultiShape3ai.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d3/ai/MultiShape3ai.java
@@ -328,7 +328,7 @@ public interface MultiShape3ai<
 			this.isPolyline = list.size() == 1
 					&& this.shapeIterator != null
 					&& this.shapeIterator.isPolyline();
-			this.isCurved = list.size() > 0
+			this.isCurved = !list.isEmpty()
 					&& this.shapeIterator != null
 					&& this.shapeIterator.isCurved();
 		}

--- a/core/math/src/main/java/org/arakhne/afc/math/tree/node/AbstractParentlessTreeNode.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/tree/node/AbstractParentlessTreeNode.java
@@ -271,7 +271,7 @@ public abstract class AbstractParentlessTreeNode<D, N extends AbstractParentless
 	@Override
 	@Pure
 	public D getUserData() {
-		if ((this.data == null) || (this.data.size() == 0)) {
+		if ((this.data == null) || (this.data.isEmpty())) {
 			return null;
 		}
 		return this.data.get(0);
@@ -294,7 +294,7 @@ public abstract class AbstractParentlessTreeNode<D, N extends AbstractParentless
 
 	@Override
 	public boolean addUserData(Collection<? extends D> data) {
-		if ((data == null) || (data.size() == 0)) {
+		if ((data == null) || (data.isEmpty())) {
 			return false;
 		}
 
@@ -315,7 +315,7 @@ public abstract class AbstractParentlessTreeNode<D, N extends AbstractParentless
 
 	@Override
 	public final boolean addUserData(int index, Collection<? extends D> data) {
-		if ((data == null) || (data.size() == 0)) {
+		if ((data == null) || (data.isEmpty())) {
 			return false;
 		}
 
@@ -346,11 +346,11 @@ public abstract class AbstractParentlessTreeNode<D, N extends AbstractParentless
 
 	@Override
 	public boolean removeUserData(Collection<D> data) {
-		if ((data == null) || (data.size() == 0) || (this.data == null)) {
+		if ((data == null) || (data.isEmpty()) || (this.data == null)) {
 			return false;
 		}
 		if (this.data.removeAll(data)) {
-			if (this.data.size() == 0) {
+			if (this.data.isEmpty()) {
 				this.data = null;
 			}
 			firePropertyDataChanged(data, null);
@@ -366,7 +366,7 @@ public abstract class AbstractParentlessTreeNode<D, N extends AbstractParentless
 		}
 		final D removedElement = this.data.remove(index);
 		if (removedElement != null) {
-			if (this.data.size() == 0) {
+			if (this.data.isEmpty()) {
 				this.data = null;
 			}
 			firePropertyDataChanged(Collections.singleton(removedElement), null);
@@ -396,7 +396,7 @@ public abstract class AbstractParentlessTreeNode<D, N extends AbstractParentless
 
 		final List<D> oldData = this.data;
 
-		if ((data == null) || (data.size() == 0)) {
+		if ((data == null) || (data.isEmpty())) {
 			this.data = null;
 		} else {
 			this.data = new ArrayList<>(data);


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1155 - “Collection.isEmpty() should be used to test for emptiness”. 
This PR will remove 66min of TD.
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1155
 Please let me know if you have any questions.
 Fevzi Ozgul