### PR TITLE
Fixing squid: S1151 "switch case" clauses should not have too many lines

### DIFF
--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/afp/OrientedRectangle2afp.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/afp/OrientedRectangle2afp.java
@@ -1831,7 +1831,7 @@ public interface OrientedRectangle2afp<
             case LINE_TO:
                 return getLineToFromNext(elem);
             case MOVE_TO:
-                return getLineToFromNext(elem);
+                return getMoveToFromNext(elem);
             case QUAD_TO:
                 return getQuadToFromNext(elem);
             case CLOSE:

--- a/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/afp/OrientedRectangle2afp.java
+++ b/core/math/src/main/java/org/arakhne/afc/math/geometry/d2/afp/OrientedRectangle2afp.java
@@ -1825,80 +1825,103 @@ public interface OrientedRectangle2afp<
             final PathElement2afp elem = this.iterator.next();
             switch (elem.getType()) {
             case CURVE_TO:
-                return getGeomFactory().newCurvePathElement(
-                        findsVectorProjectionRAxisVector(this.axisX1, this.axisY1,
-                                elem.getFromX() - this.centerX, elem.getFromY() - this.centerY),
-                        findsVectorProjectionSAxisVector(this.axisX1, this.axisY1,
-                                elem.getFromX() - this.centerX, elem.getFromY() - this.centerY),
-                        findsVectorProjectionRAxisVector(this.axisX1, this.axisY1,
-                                elem.getCtrlX1() - this.centerX, elem.getCtrlY1() - this.centerY),
-                        findsVectorProjectionSAxisVector(this.axisX1, this.axisY1,
-                                elem.getCtrlX1() - this.centerX, elem.getCtrlY1() - this.centerY),
-                        findsVectorProjectionRAxisVector(this.axisX1, this.axisY1,
-                                elem.getCtrlX2() - this.centerX, elem.getCtrlY2() - this.centerY),
-                        findsVectorProjectionSAxisVector(this.axisX1, this.axisY1,
-                                elem.getCtrlX2() - this.centerX, elem.getCtrlY2() - this.centerY),
-                        findsVectorProjectionRAxisVector(this.axisX1, this.axisY1,
-                                elem.getToX() - this.centerX, elem.getToY() - this.centerY),
-                        findsVectorProjectionSAxisVector(this.axisX1, this.axisY1,
-                                elem.getToX() - this.centerX, elem.getToY() - this.centerY));
+                return getCurvToFromNext(elem);
             case ARC_TO:
-                return getGeomFactory().newArcPathElement(
-                        findsVectorProjectionRAxisVector(this.axisX1, this.axisY1,
-                                elem.getFromX() - this.centerX, elem.getFromY() - this.centerY),
-                        findsVectorProjectionSAxisVector(this.axisX1, this.axisY1,
-                                elem.getFromX() - this.centerX, elem.getFromY() - this.centerY),
-                        findsVectorProjectionRAxisVector(this.axisX1, this.axisY1,
-                                elem.getToX() - this.centerX, elem.getToY() - this.centerY),
-                        findsVectorProjectionSAxisVector(this.axisX1, this.axisY1,
-                                elem.getToX() - this.centerX, elem.getToY() - this.centerY),
-                        elem.getRadiusX(), elem.getRadiusY(), elem.getRotationX(),
-                        elem.getLargeArcFlag(), elem.getSweepFlag());
+                return getArcToFromNext(elem);
             case LINE_TO:
-                return getGeomFactory().newLinePathElement(
-                        findsVectorProjectionRAxisVector(this.axisX1, this.axisY1,
-                                elem.getFromX() - this.centerX, elem.getFromY() - this.centerY),
-                        findsVectorProjectionSAxisVector(this.axisX1, this.axisY1,
-                                elem.getFromX() - this.centerX, elem.getFromY() - this.centerY),
-                        findsVectorProjectionRAxisVector(this.axisX1, this.axisY1,
-                                elem.getToX() - this.centerX, elem.getToY() - this.centerY),
-                        findsVectorProjectionSAxisVector(this.axisX1, this.axisY1,
-                                elem.getToX() - this.centerX, elem.getToY() - this.centerY));
+                return getLineToFromNext(elem);
             case MOVE_TO:
-                return getGeomFactory().newMovePathElement(
-                        findsVectorProjectionRAxisVector(this.axisX1, this.axisY1,
-                                elem.getToX() - this.centerX, elem.getToY() - this.centerY),
-                        findsVectorProjectionSAxisVector(this.axisX1, this.axisY1,
-                                elem.getToX() - this.centerX, elem.getToY() - this.centerY));
+                return getLineToFromNext(elem);
             case QUAD_TO:
-                return getGeomFactory().newCurvePathElement(
-                        findsVectorProjectionRAxisVector(this.axisX1, this.axisY1,
-                                elem.getFromX() - this.centerX, elem.getFromY() - this.centerY),
-                        findsVectorProjectionSAxisVector(this.axisX1, this.axisY1,
-                                elem.getFromX() - this.centerX, elem.getFromY() - this.centerY),
-                        findsVectorProjectionRAxisVector(this.axisX1, this.axisY1,
-                                elem.getCtrlX1() - this.centerX, elem.getCtrlY1() - this.centerY),
-                        findsVectorProjectionSAxisVector(this.axisX1, this.axisY1,
-                                elem.getCtrlX1() - this.centerX, elem.getCtrlY1() - this.centerY),
-                        findsVectorProjectionRAxisVector(this.axisX1, this.axisY1,
-                                elem.getToX() - this.centerX, elem.getToY() - this.centerY),
-                        findsVectorProjectionSAxisVector(this.axisX1, this.axisY1,
-                                elem.getToX() - this.centerX, elem.getToY() - this.centerY));
+                return getQuadToFromNext(elem);
             case CLOSE:
-                return getGeomFactory().newClosePathElement(
-                        findsVectorProjectionRAxisVector(this.axisX1, this.axisY1,
-                                elem.getFromX() - this.centerX, elem.getFromY() - this.centerY),
-                        findsVectorProjectionSAxisVector(this.axisX1, this.axisY1,
-                                elem.getFromX() - this.centerX, elem.getFromY() - this.centerY),
-                        findsVectorProjectionRAxisVector(this.axisX1, this.axisY1,
-                                elem.getToX() - this.centerX, elem.getToY() - this.centerY),
-                        findsVectorProjectionSAxisVector(this.axisX1, this.axisY1,
-                                elem.getToX() - this.centerX, elem.getToY() - this.centerY));
+                return getCloseFromNext(elem);
             default:
                 break;
-
             }
             return null;
+        }
+
+        private T getMoveToFromNext(PathElement2afp elem) {
+            return getGeomFactory().newMovePathElement(
+                    findsVectorProjectionRAxisVector(this.axisX1, this.axisY1,
+                            elem.getToX() - this.centerX, elem.getToY() - this.centerY),
+                    findsVectorProjectionSAxisVector(this.axisX1, this.axisY1,
+                            elem.getToX() - this.centerX, elem.getToY() - this.centerY));
+        }
+
+        private T getCurvToFromNext(PathElement2afp elem) {
+            return getGeomFactory().newCurvePathElement(
+                    findsVectorProjectionRAxisVector(this.axisX1, this.axisY1,
+                            elem.getFromX() - this.centerX, elem.getFromY() - this.centerY),
+                    findsVectorProjectionSAxisVector(this.axisX1, this.axisY1,
+                            elem.getFromX() - this.centerX, elem.getFromY() - this.centerY),
+                    findsVectorProjectionRAxisVector(this.axisX1, this.axisY1,
+                            elem.getCtrlX1() - this.centerX, elem.getCtrlY1() - this.centerY),
+                    findsVectorProjectionSAxisVector(this.axisX1, this.axisY1,
+                            elem.getCtrlX1() - this.centerX, elem.getCtrlY1() - this.centerY),
+                    findsVectorProjectionRAxisVector(this.axisX1, this.axisY1,
+                            elem.getCtrlX2() - this.centerX, elem.getCtrlY2() - this.centerY),
+                    findsVectorProjectionSAxisVector(this.axisX1, this.axisY1,
+                            elem.getCtrlX2() - this.centerX, elem.getCtrlY2() - this.centerY),
+                    findsVectorProjectionRAxisVector(this.axisX1, this.axisY1,
+                            elem.getToX() - this.centerX, elem.getToY() - this.centerY),
+                    findsVectorProjectionSAxisVector(this.axisX1, this.axisY1,
+                            elem.getToX() - this.centerX, elem.getToY() - this.centerY));
+        }
+
+        private T getArcToFromNext(PathElement2afp elem) {
+            return getGeomFactory().newArcPathElement(
+                    findsVectorProjectionRAxisVector(this.axisX1, this.axisY1,
+                            elem.getFromX() - this.centerX, elem.getFromY() - this.centerY),
+                    findsVectorProjectionSAxisVector(this.axisX1, this.axisY1,
+                            elem.getFromX() - this.centerX, elem.getFromY() - this.centerY),
+                    findsVectorProjectionRAxisVector(this.axisX1, this.axisY1,
+                            elem.getToX() - this.centerX, elem.getToY() - this.centerY),
+                    findsVectorProjectionSAxisVector(this.axisX1, this.axisY1,
+                            elem.getToX() - this.centerX, elem.getToY() - this.centerY),
+                    elem.getRadiusX(), elem.getRadiusY(), elem.getRotationX(),
+                    elem.getLargeArcFlag(), elem.getSweepFlag());
+        }
+
+        private T getLineToFromNext(PathElement2afp elem) {
+            return getGeomFactory().newLinePathElement(
+                    findsVectorProjectionRAxisVector(this.axisX1, this.axisY1,
+                            elem.getFromX() - this.centerX, elem.getFromY() - this.centerY),
+                    findsVectorProjectionSAxisVector(this.axisX1, this.axisY1,
+                            elem.getFromX() - this.centerX, elem.getFromY() - this.centerY),
+                    findsVectorProjectionRAxisVector(this.axisX1, this.axisY1,
+                            elem.getToX() - this.centerX, elem.getToY() - this.centerY),
+                    findsVectorProjectionSAxisVector(this.axisX1, this.axisY1,
+                            elem.getToX() - this.centerX, elem.getToY() - this.centerY));
+        }
+
+        private T getQuadToFromNext(PathElement2afp elem) {
+            return getGeomFactory().newCurvePathElement(
+                    findsVectorProjectionRAxisVector(this.axisX1, this.axisY1,
+                            elem.getFromX() - this.centerX, elem.getFromY() - this.centerY),
+                    findsVectorProjectionSAxisVector(this.axisX1, this.axisY1,
+                            elem.getFromX() - this.centerX, elem.getFromY() - this.centerY),
+                    findsVectorProjectionRAxisVector(this.axisX1, this.axisY1,
+                            elem.getCtrlX1() - this.centerX, elem.getCtrlY1() - this.centerY),
+                    findsVectorProjectionSAxisVector(this.axisX1, this.axisY1,
+                            elem.getCtrlX1() - this.centerX, elem.getCtrlY1() - this.centerY),
+                    findsVectorProjectionRAxisVector(this.axisX1, this.axisY1,
+                            elem.getToX() - this.centerX, elem.getToY() - this.centerY),
+                    findsVectorProjectionSAxisVector(this.axisX1, this.axisY1,
+                            elem.getToX() - this.centerX, elem.getToY() - this.centerY));
+        }
+
+        private T getCloseFromNext(PathElement2afp elem) {
+            return getGeomFactory().newClosePathElement(
+                    findsVectorProjectionRAxisVector(this.axisX1, this.axisY1,
+                            elem.getFromX() - this.centerX, elem.getFromY() - this.centerY),
+                    findsVectorProjectionSAxisVector(this.axisX1, this.axisY1,
+                            elem.getFromX() - this.centerX, elem.getFromY() - this.centerY),
+                    findsVectorProjectionRAxisVector(this.axisX1, this.axisY1,
+                            elem.getToX() - this.centerX, elem.getToY() - this.centerY),
+                    findsVectorProjectionSAxisVector(this.axisX1, this.axisY1,
+                            elem.getToX() - this.centerX, elem.getToY() - this.centerY));
         }
 
         @Override


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1151 - “""switch case"" clauses should not have too many lines”. 
This PR will remove 30min of TD.
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1151
 Please let me know if you have any questions.
Fevzi Ozgul