### PR TITLE
Fixing squid: S2583  Conditions should not unconditionally evaluate to "TRUE" or to "FALSE"

### DIFF
--- a/core/testtools/src/main/java/org/arakhne/afc/testtools/AbstractTestCase.java
+++ b/core/testtools/src/main/java/org/arakhne/afc/testtools/AbstractTestCase.java
@@ -168,16 +168,14 @@ public abstract class AbstractTestCase extends EnableAssertion {
 		if (v1 == v2) {
 			return true;
 		}
-		if (v1 == null && v2 != null) {
+		if (v1 == null || v2 == null) {
 			return false;
 		}
-		if (v1 != null && v2 == null) {
-			return false;
-		}
-		assert v1 != null && v2 != null;
+
 		if (v1.length != v2.length) {
 			return false;
 		}
+		assert v1 != null && v2 != null;
 		for (int i = 0; i < v1.length; ++i) {
 			if (!isEpsilonEquals(v1[i], v2[i])) {
 				return false;
@@ -1192,16 +1190,12 @@ public abstract class AbstractTestCase extends EnableAssertion {
 		if (expected == actual) {
 			return;
 		}
-		if (expected == null && actual != null) {
+		if (expected == null || actual == null) {
 			throw new ComparisonFailure(formatFailMessage("not same", expected, actual), //$NON-NLS-1$
 					null,
 					actual.toString());
 		}
-		if (expected != null && actual == null) {
-			throw new ComparisonFailure(formatFailMessage("not same", expected, actual), //$NON-NLS-1$
-					expected.toString(),
-					null);
-		}
+
 		assert expected != null && actual != null;
 		final DateFormat fmt = new SimpleDateFormat("yyyy-MM-dd"); //$NON-NLS-1$
 		final String expectedStr = fmt.format(expected);

--- a/core/testtools/src/main/java/org/arakhne/afc/testtools/AbstractTestCase.java
+++ b/core/testtools/src/main/java/org/arakhne/afc/testtools/AbstractTestCase.java
@@ -1190,10 +1190,16 @@ public abstract class AbstractTestCase extends EnableAssertion {
 		if (expected == actual) {
 			return;
 		}
-		if (expected == null || actual == null) {
+		if (expected == null) {
 			throw new ComparisonFailure(formatFailMessage("not same", expected, actual), //$NON-NLS-1$
 					null,
 					actual.toString());
+		}
+
+		if (actual == null) {
+			throw new ComparisonFailure(formatFailMessage("not same", expected, actual), //$NON-NLS-1$
+					null,
+					expected.toString());
 		}
 
 		assert expected != null && actual != null;


### PR DESCRIPTION
  This pull request is focused on resolving occurrences of Sonar rule 
 squid:S2583 - “ Conditions should not unconditionally evaluate to ""TRUE"" or to ""FALSE"" ”. 
This PR will remove 60 min of TD.
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S2583
 Please let me know if you have any questions.
Fevzi Ozgul